### PR TITLE
vote config with struct

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## v0.0.1-alpha
 
 - First version of the package, exposing the JSON artifacts
+- Added `VoteConfig` struct in the `DAOFactory` to allow better typechain support for the creation of daos.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Aragon Core contracts
 
-## v0.0.1-alpha
+## v0.1.0-alpha
+- Added `VoteConfig` struct in the `DAOFactory` to allow better typechain support for the creation of daos. 
 
-- First version of the package, exposing the JSON artifacts
-- Added `VoteConfig` struct in the `DAOFactory` to allow better typechain support for the creation of daos.
+## v0.0.1-alpha
+- First version of the package, exposing the JSON artifacts creation of daos.

--- a/packages/contracts/test/dao-factory.ts
+++ b/packages/contracts/test/dao-factory.ts
@@ -22,7 +22,11 @@ const ACLAnyAddress = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
 const ACLAllowFlagAddress = '0x0000000000000000000000000000000000000002';
 const daoDummyName = 'dao1';
 const daoDummyMetadata = '0x0000';
-const dummyVoteSettings = [1, 2, 3];
+const dummyVoteSettings = {
+  participationRequiredPct: 1,
+  supportRequiredPct: 2,
+  minDuration: 3
+}
 
 async function getDeployments(tx: any, tokenVoting: boolean) {
   const data = await tx.wait();
@@ -172,9 +176,9 @@ describe('DAOFactory: ', function () {
       .withArgs(daoDummyMetadata)
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(
-        dummyVoteSettings[0],
-        dummyVoteSettings[1],
-        dummyVoteSettings[2]
+        dummyVoteSettings.participationRequiredPct,
+        dummyVoteSettings.supportRequiredPct,
+        dummyVoteSettings.minDuration
       );
 
     // @ts-ignore
@@ -296,9 +300,9 @@ describe('DAOFactory: ', function () {
       .withArgs(daoDummyMetadata)
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(
-        dummyVoteSettings[0],
-        dummyVoteSettings[1],
-        dummyVoteSettings[2]
+        dummyVoteSettings.participationRequiredPct,
+        dummyVoteSettings.supportRequiredPct,
+        dummyVoteSettings.minDuration
       );
 
     // @ts-ignore


### PR DESCRIPTION
## Description

The following PR brings the `VoteConfig` struct in order to make easier for sdk to include typechain support.

There're some things that would need a little bit of thought.

1. We could bring `VoteConfig` struct in the `MajorityVoting`, but due to the nature of not being able to do inheritance on structs, it would be really hard to upgrade WhitelistVoting contract if it needs one more variable in the config and for ERC20Voting, if the config should stay the same way. Hence, including this in MajorityVoting is kind of tricky.

2. Even if We do the above and assume that VoteConfig will always be the same for `WhitelistVoting` and `ERC20Voting`,  There's one more thing to keep in mind. Since it's a struct, new developers might come right away and decide to add one more variable into the struct, hence overwriting the variable that comes after the struct. So, we should be pretty careful with structs. It's easy to tell developers to always include state variables by the end of all other state variables, but it's pretty dangerous to follow the same principle when it's about the struct, since one might assume that adding a variable in the struct might be safe.

One of the solution is to bring some kind of `_gap` such as `uint[10] _gap` and reserving 10 variables by the end of the struct.

```
struct VoteConfig {
    uint a;
    uint b;
    uint c;
    uint[10] _gap;
}
```

But in the beginning of very first contracts, we would have higher storage fees (not by much in case of Arbitrum), but still, some carefulness is needed here.

Just describing all this to come back to this later and decide on something. As of now, current changes should be solving dao factory's typechain.
