### PR TITLE
Complete the IDAO interface

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Made `DAO` a `BaseRelayRecipient`
 - Added `VoteConfig` struct in the `DAOFactory` to allow better typechain support for the creation of daos. 
 - Added `MetaTxComponent`.
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Made `DAO` a `BaseRelayRecipient`
 - Added `VoteConfig` struct in the `DAOFactory` to allow better typechain support for the creation of daos. 
 - Added `MetaTxComponent`.
 
 ### Changed
 
+- Renamed the event `SetMetadata` to `MetadataSet`
+- Completed the `IDAO` interface and changed `DAO` accordingly
 - Decoupled `Permissions` from `BaseRelayRecipient`.
 - Fixed OZ contracts-upgradable `Initializable`.
 

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -16,7 +16,7 @@ import "./IDAO.sol";
 
 /// @title The public interface of the Aragon DAO framework.
 /// @author Samuel Furter - Aragon Association - 2021
-/// @notice This contract is the entry point to the Aragon DAO framework and provides our users a simple and use to use public interface.
+/// @notice This contract is the entry point to the Aragon DAO framework and provides our users a simple and easy to use public interface.
 /// @dev Public API of the Aragon DAO framework
 contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC165 {
     using SafeERC20 for ERC20;
@@ -30,7 +30,10 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     bytes32 public constant SET_SIGNATURE_VALIDATOR_ROLE = keccak256("SET_SIGNATURE_VALIDATOR_ROLE");
     bytes32 public constant MODIFY_TRUSTED_FORWARDER = keccak256("MODIFY_TRUSTED_FORWARDER");
 
-    // Error msg's
+    ERC1271 signatureValidator;
+
+    address private _trustedForwarder;
+
     /// @notice Thrown if action execution has failed
     error ActionFailed();
 
@@ -44,10 +47,6 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
 
     /// @notice Thrown if an ETH withdraw fails
     error ETHWithdrawFailed();
-
-    ERC1271 signatureValidator;
-
-    address private _trustedForwarder;
 
     /// @dev Used for UUPS upgradability pattern
     /// @param _metadata IPFS hash that points to all the metadata (logo, description, tags, etc.) of a DAO

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -46,8 +46,6 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     /// @notice Thrown if an ETH withdraw fails
     error ETHWithdrawFailed();
 
-    event TrustedForwarderSet(address forwarder);
-
     ERC1271 signatureValidator;
 
     /// @dev Used for UUPS upgradability pattern
@@ -74,20 +72,19 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     /// @dev Used to check the permissions within the upgradability pattern implementation of OZ
     function _authorizeUpgrade(address) internal virtual override auth(address(this), UPGRADE_ROLE) {}
     
-    /// @notice set trusted forwarder on the DAO
-    /// @param _forwarder address of the forwarder
+    /// @inheritdoc IDAO
     function setTrustedForwarder(
-        address _forwarder
-    ) external auth(address(this), MODIFY_TRUSTED_FORWARDER) {
-        _setTrustedForwarder(_forwarder);
+        address _trustedForwarder
+    ) external override auth(address(this), MODIFY_TRUSTED_FORWARDER) {
+        _setTrustedForwarder(_trustedForwarder);
     }
 
-    /// @notice Checks if the current callee has the permissions for.
-    /// @dev Wrapper for the willPerform method of ACL to later on be able to use it in the modifier of the sub components of this DAO.
-    /// @param _where Which contract does get called
-    /// @param _who Who is calling this method
-    /// @param _role Which role is required to call this
-    /// @param _data Additional data used in the ACLOracle
+    /// @inheritdoc IDAO
+    function trustedForwarder() public virtual override (IDAO, BaseRelayRecipient) view returns (address){
+        return BaseRelayRecipient.trustedForwarder();
+    }
+
+    /// @inheritdoc IDAO
     function hasPermission(
         address _where,
         address _who,
@@ -97,17 +94,12 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         return willPerform(_where, _who, _role, _data);
     }
 
-    /// @notice Update the DAO metadata
-    /// @dev Sets a new IPFS hash
-    /// @param _metadata The IPFS hash of the new metadata object
+    /// @inheritdoc IDAO
     function setMetadata(bytes calldata _metadata) external override auth(address(this), DAO_CONFIG_ROLE) {
         _setMetadata(_metadata);
     }
 
-    /// @notice If called, the list of provided actions will be executed.
-    /// @dev It run a loop through the array of acctions and execute one by one.
-    /// @dev If one acction fails, all will be reverted.
-    /// @param _actions The aray of actions
+    /// @inheritdoc IDAO
     function execute(uint256 callId, Action[] memory _actions)
         external
         override
@@ -129,21 +121,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         return execResults;
     }
 
-    /// @dev Emit ETHDeposited event to track ETH deposits that weren't done over the deposit method.
-    receive() external payable {
-        emit ETHDeposited(msg.sender, msg.value);
-    }
-
-    /// @dev Fallback to handle future versions of the ERC165 standard.
-    fallback() external {
-        _handleCallback(msg.sig, msg.data); // WARN: does a low-level return, any code below would be unreacheable
-    }
-
-    /// @notice Deposit ETH or any token to this contract with a reference string
-    /// @dev Deposit ETH (token address == 0) or any token with a reference
-    /// @param _token The address of the token and in case of ETH address(0)
-    /// @param _amount The amount of tokens to deposit
-    /// @param _reference The deposit reference describing the reason of it
+    /// @inheritdoc IDAO
     function deposit(
         address _token,
         uint256 _amount,
@@ -162,11 +140,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         emit Deposited(msg.sender, _token, _amount, _reference);
     }
 
-    /// @notice Withdraw tokens or ETH from the DAO with a withdraw reference string
-    /// @param _token The address of the token and in case of ETH address(0)
-    /// @param _to The target address to send tokens or ETH
-    /// @param _amount The amount of tokens to deposit
-    /// @param _reference The deposit reference describing the reason of it
+    /// @inheritdoc IDAO
     function withdraw(
         address _token,
         address _to,
@@ -185,20 +159,16 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         emit Withdrawn(_token, _to, _amount, _reference);
     }
 
-    /// @notice Setter to set the signature validator contract of ERC1271
-    /// @param _signatureValidator ERC1271 SignatureValidator
-    function setSignatureValidator(ERC1271 _signatureValidator)
-        external
+    /// @inheritdoc IDAO
+    function setSignatureValidator(address _signatureValidator)
+        external override
         auth(address(this), SET_SIGNATURE_VALIDATOR_ROLE)
     {
-        signatureValidator = _signatureValidator;
+        signatureValidator = ERC1271(_signatureValidator);
     }
 
-    /// @notice Method to validate the signature as described in ERC1271
-    /// @param _hash Hash of the data to be signed
-    /// @param _signature Signature byte array associated with _hash
-    /// @return bytes4
-    function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
+    /// @inheritdoc IDAO
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external view override(IDAO, ERC1271) returns (bytes4) {
         if (address(signatureValidator) == address(0)) return bytes4(0); // invalid magic number
         return signatureValidator.isValidSignature(_hash, _signature); // forward call to set validation contract
     }
@@ -206,6 +176,17 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     /// Private/Internal Functions
 
     function _setMetadata(bytes calldata _metadata) internal {
-        emit SetMetadata(_metadata);
+        emit MetadataSet(_metadata);
+    }
+
+
+    /// @dev Emit ETHDeposited event to track ETH deposits that weren't done over the deposit method.
+    receive() external payable {
+        emit ETHDeposited(msg.sender, msg.value);
+    }
+
+    /// @dev Fallback to handle future versions of the ERC165 standard.
+    fallback() external {
+        _handleCallback(msg.sig, msg.data); // WARN: does a low-level return, any code below would be unreacheable
     }
 }

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -60,7 +60,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         _registerStandard(type(ERC1271).interfaceId);
 
         _setMetadata(_metadata);
-        _setTrustedForwarder(_forwarder);
+        _setTrustedForwarderWithEvent(_forwarder);
         __ACL_init(_initialOwner);
     }
 
@@ -71,7 +71,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     function setTrustedForwarder(
         address _newTrustedForwarder
     ) external override auth(address(this), MODIFY_TRUSTED_FORWARDER) {
-        _setTrustedForwarder(_newTrustedForwarder);
+        _setTrustedForwarderWithEvent(_newTrustedForwarder);
     }
 
     /// @inheritdoc IDAO
@@ -172,7 +172,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         emit MetadataSet(_metadata);
     }
 
-    function _setTrustedForwarder(address _forwarder) internal {
+    function _setTrustedForwarderWithEvent(address _forwarder) internal {
         _trustedForwarder = _forwarder;
 
         emit TrustedForwarderSet(_forwarder);

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -60,7 +60,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         _registerStandard(type(ERC1271).interfaceId);
 
         _setMetadata(_metadata);
-        _setTrustedForwarderWithEvent(_forwarder);
+        _setTrustedForwarder(_forwarder);
         __ACL_init(_initialOwner);
     }
 
@@ -71,7 +71,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     function setTrustedForwarder(
         address _newTrustedForwarder
     ) external override auth(address(this), MODIFY_TRUSTED_FORWARDER) {
-        _setTrustedForwarderWithEvent(_newTrustedForwarder);
+        _setTrustedForwarder(_newTrustedForwarder);
     }
 
     /// @inheritdoc IDAO
@@ -168,16 +168,6 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         return signatureValidator.isValidSignature(_hash, _signature); // forward call to set validation contract
     }
 
-    function _setMetadata(bytes calldata _metadata) internal {
-        emit MetadataSet(_metadata);
-    }
-
-    function _setTrustedForwarderWithEvent(address _forwarder) internal {
-        _trustedForwarder = _forwarder;
-
-        emit TrustedForwarderSet(_forwarder);
-    }
-
     /// @dev Emit ETHDeposited event to track ETH deposits that weren't done over the deposit method.
     receive() external payable {
         emit ETHDeposited(msg.sender, msg.value);
@@ -186,5 +176,15 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     /// @dev Fallback to handle future versions of the ERC165 standard.
     fallback() external {
         _handleCallback(msg.sig, msg.data); // WARN: does a low-level return, any code below would be unreacheable
+    }
+
+    function _setMetadata(bytes calldata _metadata) internal {
+        emit MetadataSet(_metadata);
+    }
+
+    function _setTrustedForwarder(address _forwarder) internal {
+        _trustedForwarder = _forwarder;
+
+        emit TrustedForwarderSet(_forwarder);
     }
 }

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -33,7 +33,7 @@ abstract contract IDAO {
     /// @param _metadata The IPFS hash of the new metadata object
     function setMetadata(bytes calldata _metadata) external virtual;
 
-    event SetMetadata(bytes metadata);
+    event MetadataSet(bytes metadata);
 
     /// @notice If called, the list of provided actions will be executed.
     /// @dev It run a loop through the array of acctions and execute one by one.
@@ -74,4 +74,25 @@ abstract contract IDAO {
     ) external virtual;
 
     event Withdrawn(address indexed token, address indexed to, uint256 amount, string _reference);
+
+    /// @notice Setter for the trusted forwarder verifying the meta transaction
+    /// @param _trustedForwarder the trusted forwarder address
+    /// @dev used to update the trusted forwarder
+    function setTrustedForwarder(address _trustedForwarder) external virtual;
+
+    /// @notice Setter for the trusted forwarder verifying the meta transaction
+    /// @return the trusted forwarder address
+    function trustedForwarder() external virtual returns (address);
+
+    event TrustedForwarderSet(address forwarder);
+
+    /// @notice Setter to set the signature validator contract of ERC1271
+    /// @param _signatureValidator ERC1271 SignatureValidator
+    function setSignatureValidator(address _signatureValidator) external virtual;
+
+    /// @notice Method to validate the signature as described in ERC1271
+    /// @param _hash Hash of the data to be signed
+    /// @param _signature Signature byte array associated with _hash
+    /// @return bytes4
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external virtual returns (bytes4);
 }

--- a/packages/contracts/contracts/core/component/MetaTxComponent.sol
+++ b/packages/contracts/contracts/core/component/MetaTxComponent.sol
@@ -20,9 +20,10 @@ abstract contract MetaTxComponent is Component, BaseRelayRecipient {
     function __MetaTxComponent_init(IDAO _dao, address _trustedForwarder) internal virtual onlyInitializing {
         __Component_init(_dao);
 
-        _setTrustedForwarderWithEvent(_trustedForwarder);
-
         _registerStandard(type(MetaTxComponent).interfaceId);
+
+        _setTrustedForwarder(_trustedForwarder);
+        emit TrustedForwarderSet(_trustedForwarder);
     }
 
     /// @notice overrides '_msgSender()' from 'Component'->'ContextUpgradeable' with that of 'BaseRelayRecipient'
@@ -39,12 +40,6 @@ abstract contract MetaTxComponent is Component, BaseRelayRecipient {
     /// @param _trustedForwarder the trusted forwarder address
     /// @dev used to update the trusted forwarder
     function setTrustedForwarder(address _trustedForwarder) public virtual auth(MODIFY_TRUSTED_FORWARDER) {
-        _setTrustedForwarderWithEvent(_trustedForwarder);
-    }
-
-    /// @dev Internal function to set the trusted forwarder and emit an event
-    /// @param _trustedForwarder the trusted forwarder address
-    function _setTrustedForwarderWithEvent(address _trustedForwarder) internal {
         _setTrustedForwarder(_trustedForwarder);
 
         emit TrustedForwarderSet(_trustedForwarder);

--- a/packages/contracts/contracts/test/DAOMock.sol
+++ b/packages/contracts/contracts/test/DAOMock.sol
@@ -26,9 +26,13 @@ contract DAOMock is IDAO, ACL {
         return true;
     }
 
-    function trustedForwarder() public virtual view returns(address) {
+    function trustedForwarder() public override pure returns(address) {
         return address(0);
     }
+
+    function setTrustedForwarder(
+        address /* _trustedForwarder */
+    ) external override {}
 
     function setMetadata(
         bytes calldata /* _metadata */
@@ -52,4 +56,13 @@ contract DAOMock is IDAO, ACL {
         uint256, /* _amount */
         string memory /* _reference */
     ) public override {}
+
+    function setSignatureValidator(address  /* _signatureValidator */) external override {}
+
+    function isValidSignature(
+        bytes32, /* _hash */ 
+        bytes memory /* _signature */
+        ) external pure override returns (bytes4) {
+        return 0x0;
+    }
 }

--- a/packages/contracts/test/core/dao.ts
+++ b/packages/contracts/test/core/dao.ts
@@ -1,0 +1,343 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import chaiUtils from '../test-utils';
+import { ERRORS, customError } from '../test-utils/custom-error-helper';
+
+chai.use(chaiUtils);
+
+import { DAO, GovernanceERC20 } from '../../typechain';
+
+import { SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
+
+const dummyAddress1 = '0x0000000000000000000000000000000000000001';
+const dummyAddress2 = '0x0000000000000000000000000000000000000002';
+const dummyMetadata1 = '0x0001';
+const dummyMetadata2 = '0x0002';
+
+
+const EVENTS = {
+  MetadataSet: 'MetadataSet',
+  TrustedForwarderSet: 'TrustedForwarderSet',
+  UpdateConfig: 'UpdateConfig',
+  DAOCreated: 'DAOCreated',
+  Granted: 'Granted',
+  Revoked: 'Revoked',
+  Deposited: 'Deposited',
+  Withdrawn: 'Withdrawn',
+  Executed: 'Executed',
+  ETHDeposited: 'ETHDeposited'
+};
+
+const ROLES = {
+  UPGRADE_ROLE: ethers.utils.id('UPGRADE_ROLE'),
+  DAO_CONFIG_ROLE: ethers.utils.id('DAO_CONFIG_ROLE'),
+  EXEC_ROLE: ethers.utils.id('EXEC_ROLE'),
+  WITHDRAW_ROLE: ethers.utils.id('WITHDRAW_ROLE'),
+  SET_SIGNATURE_VALIDATOR_ROLE: ethers.utils.id('SET_SIGNATURE_VALIDATOR_ROLE'),
+  MODIFY_TRUSTED_FORWARDER: ethers.utils.id('MODIFY_TRUSTED_FORWARDER'),
+  TOKEN_MINTER_ROLE: ethers.utils.id('TOKEN_MINTER_ROLE')
+}
+
+describe('DAO', function () {
+  let signers: SignerWithAddress[];
+  let ownerAddress: string;
+  let dao: DAO;
+  let token: GovernanceERC20;
+
+  beforeEach(async () => {
+    signers = await ethers.getSigners();
+    ownerAddress = await signers[0].getAddress();
+
+    const DAO = await ethers.getContractFactory('DAO');
+    dao = await DAO.deploy();
+    await dao.initialize(dummyMetadata1, ownerAddress, dummyAddress1);
+
+    const Token = await ethers.getContractFactory('GovernanceERC20');
+    token = await Token.deploy();
+    await token.initialize(dao.address, "GOV", "GOV");
+
+    // Grant Roles
+    await Promise.all([
+      dao.grant(dao.address, ownerAddress, ROLES.DAO_CONFIG_ROLE),
+      dao.grant(dao.address, ownerAddress, ROLES.EXEC_ROLE),
+      dao.grant(dao.address, ownerAddress, ROLES.WITHDRAW_ROLE),
+      dao.grant(dao.address, ownerAddress, ROLES.UPGRADE_ROLE),
+      dao.grant(dao.address, ownerAddress, ROLES.SET_SIGNATURE_VALIDATOR_ROLE),
+      dao.grant(dao.address, ownerAddress, ROLES.MODIFY_TRUSTED_FORWARDER),
+      dao.grant(token.address, ownerAddress, ROLES.TOKEN_MINTER_ROLE)
+    ]);
+  });
+
+  describe('initialize', async () => {
+    it('reverts if trying to re-initialize', async () => {
+      await expect(
+        dao.initialize(dummyMetadata1, ownerAddress, dummyAddress1)
+      ).to.be.revertedWith(ERRORS.ALREADY_INITIALIZED);
+    });
+
+    it('sets the trusted forwarder correctly', async () => {
+      expect(
+        await dao.trustedForwarder()
+      ).to.be.equal(dummyAddress1);
+    });
+  });
+
+  describe('setTrustedForwarder:', async () => {
+    it('reverts if the sender lacks the required role', async () => {
+      await dao.revoke(dao.address, ownerAddress, ROLES.MODIFY_TRUSTED_FORWARDER)
+
+      await expect(
+        dao.setTrustedForwarder(dummyAddress2)
+      ).to.be.revertedWith(
+          customError('ACLAuth', dao.address, dao.address, ownerAddress, ROLES.MODIFY_TRUSTED_FORWARDER)
+        );
+    })
+
+    it('sets a new trusted forwarder', async () => {
+      await dao.setTrustedForwarder(dummyAddress2);
+      expect(
+        await dao.trustedForwarder()
+      ).to.be.equal(dummyAddress2);
+    });
+
+    it('emits an event containing the address', async () => {
+      expect( 
+        await dao.setTrustedForwarder(dummyAddress2)
+      ).to.emit(dao, EVENTS.TrustedForwarderSet)
+       .withArgs(dummyAddress2);
+    });
+  });
+
+  describe('setMetadata:', async () => {
+    it('reverts if the sender lacks the required role', async () => {
+      await dao.revoke(dao.address, ownerAddress, ROLES.DAO_CONFIG_ROLE)
+
+      await expect(
+        dao.setMetadata(dummyMetadata1)
+      ).to.be.revertedWith(
+          customError('ACLAuth', dao.address, dao.address, ownerAddress, ROLES.DAO_CONFIG_ROLE)
+        );
+    })
+
+    it('sets new metadata via an event', async () => {
+      expect(
+        await dao.setMetadata(dummyMetadata2)
+      )
+      .to.emit(dao, EVENTS.MetadataSet)
+      .withArgs(dummyMetadata2);
+    });
+  });
+
+  describe('setSignatureValidator:', async () => {
+    it('reverts if the sender lacks the required role', async () => {
+      await dao.revoke(dao.address, ownerAddress, ROLES.SET_SIGNATURE_VALIDATOR_ROLE)
+
+      await expect(
+        dao.setSignatureValidator(dummyAddress2)
+      ).to.be.revertedWith(
+          customError('ACLAuth', dao.address, dao.address, ownerAddress, ROLES.SET_SIGNATURE_VALIDATOR_ROLE)
+        );
+    })
+
+    it.skip('sets a new signature validator', async () => {
+      expect(false).to.be.equal(true); // TODO
+    });
+
+    it.skip('validates signatures', async () => {
+      expect(false).to.be.equal(true); // TODO
+    });
+  });
+
+  describe('execute:', async () => {
+    const dummyActions = [
+      {
+        to: dummyAddress1,
+        data: dummyMetadata1,
+        value: 0,
+      },
+    ];
+    const expectedDummyResults = ['0x']
+
+    it('reverts if the sender lacks the required role', async () => {
+      await dao.revoke(dao.address, ownerAddress, ROLES.EXEC_ROLE)
+
+      await expect(
+        dao.execute(0 ,dummyActions)
+      ).to.be.revertedWith(
+          customError('ACLAuth', dao.address, dao.address, ownerAddress, ROLES.EXEC_ROLE)
+      );
+    })
+
+    it('executes an array of actions', async () => {
+      expect(
+        await dao.callStatic.execute(0, dummyActions)
+      ).to.be.equal(expectedDummyResults);
+    });
+
+    it('emits an event afterwards', async () => {
+      expect(await dao.execute(0, dummyActions))
+        .to.emit(dao, EVENTS.Executed)
+        .withArgs(
+          ownerAddress,
+          0,
+          [
+            [
+              dummyActions[0].to,
+              ethers.BigNumber.from(dummyActions[0].value),
+              dummyActions[0].data,
+            ],
+          ],
+          expectedDummyResults
+        );
+    });
+  });
+
+  describe('deposit:', async () => {
+    const amount = ethers.utils.parseEther('1.23');
+
+    it('deposits ETH into the DAO', async () => {
+      const options = {value: amount};
+
+      // is empty at the beginning
+      expect(
+        await ethers.provider.getBalance(dao.address)
+      ).to.equal(0);
+
+      expect(
+        await dao.deposit(ethers.constants.AddressZero, amount, 'ref', options)
+      ).to.emit(dao, EVENTS.Deposited)
+      .withArgs(ownerAddress, ethers.constants.AddressZero, amount, 'ref');
+
+      // holds amount now
+      expect(
+        await ethers.provider.getBalance(dao.address)
+      ).to.equal(amount);
+    });
+
+    it('deposits ERC20 into the DAO', async () => {
+      await token.mint(ownerAddress, amount);
+      await token.approve(dao.address, amount);
+
+      // is empty at the beginning
+      expect(
+        await token.balanceOf(dao.address)
+      ).to.equal(0);
+
+      expect(
+        await dao.deposit(token.address, amount, 'ref')
+      ).to.emit(dao, EVENTS.Deposited)
+      .withArgs(ownerAddress, token.address, amount, 'ref');
+
+      // holds amount now
+      expect(
+        await token.balanceOf(dao.address)
+      ).to.equal(amount);
+    });
+
+    it('throws an error if ERC20 and ETH are deposited at the same time', async () => {
+      const options = {value: amount};
+      await token.mint(ownerAddress, amount);
+
+      await expect(
+        dao.deposit(token.address, amount, 'ref', options)
+      ).to.be.revertedWith(
+          customError('ETHDepositAmountMismatch',0, amount)
+      );
+    });
+  });
+
+  describe('withdraw:', async () => {
+    const amount = ethers.utils.parseEther('1.23');
+    const options = {value: amount};
+
+    beforeEach(async () => {
+      // put ETH into the DAO
+      await dao.deposit(ethers.constants.AddressZero, amount, 'ref', options)
+      
+      // put ERC20 into the DAO
+      await token.mint(dao.address, amount);
+    });
+
+    it('reverts if the sender lacks the required role', async () => {
+      await dao.revoke(dao.address, ownerAddress, ROLES.WITHDRAW_ROLE)
+
+      await expect(
+        dao.withdraw(ethers.constants.AddressZero, ownerAddress, amount, 'ref')
+      ).to.be.revertedWith(
+          customError('ACLAuth', dao.address, dao.address, ownerAddress, ROLES.WITHDRAW_ROLE)
+      );
+    });
+
+    it('withdraws ETH if DAO balance is high enough', async () => {
+      const receiverBalance = await signers[1].getBalance();
+
+      expect(
+        await dao.withdraw(ethers.constants.AddressZero, signers[1].address, amount, 'ref')
+      ).to.emit(dao, EVENTS.Withdrawn)
+      .withArgs(ethers.constants.AddressZero, signers[1].address, amount, 'ref');
+
+      expect(
+        await signers[1].getBalance()
+      ).to.equal(receiverBalance.add(amount))
+    });
+
+    it('throws an error if the ETH balance is too low', async () => {
+      await expect(
+        dao.withdraw(ethers.constants.AddressZero, ownerAddress, amount.add(1), 'ref')
+      ).to.be.revertedWith(
+          customError('ETHWithdrawFailed')
+      );
+    });
+
+    it('withdraws ERC20 if DAO balance is high enough', async () => {
+      const receiverBalance = await token.balanceOf(signers[1].address);
+
+      expect(
+        await dao.withdraw(token.address, signers[1].address, amount, 'ref')
+      ).to.emit(dao, EVENTS.Withdrawn)
+      .withArgs(token.address, signers[1].address, amount, 'ref');
+
+      expect(
+        await token.balanceOf(signers[1].address)
+      ).to.equal(receiverBalance.add(amount))
+    });
+
+    it('throws an error if the ERC20 balance is too low', async () => {
+      await expect(
+        dao.withdraw(token.address, ownerAddress, amount.add(1), 'ref')
+      ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
+    });
+
+    it('throws an error if the amount is 0', async () => {
+      await expect(
+        dao.withdraw(token.address, ownerAddress, 0, 'ref')
+      ).to.be.revertedWith(
+          customError('ZeroAmount')
+      );
+    });
+  });
+
+  describe('receive:', async () => {
+    const amount = ethers.utils.parseEther('1.23');
+
+    it('receives ETH ', async () => {
+      const options = {value: amount};
+
+      // is empty at the beginning
+      expect(
+        await ethers.provider.getBalance(dao.address)
+      ).to.equal(0);
+
+      // Send a transaction
+      expect(
+        await signers[0].sendTransaction({to: dao.address, value: amount})
+      ).to.emit(dao, EVENTS.ETHDeposited)
+      .withArgs(ownerAddress, amount);
+
+      // holds amount now
+      expect(
+        await ethers.provider.getBalance(dao.address)
+      ).to.equal(amount);
+    });
+  });  
+});

--- a/packages/contracts/test/dao-factory.ts
+++ b/packages/contracts/test/dao-factory.ts
@@ -12,7 +12,7 @@ const EVENTS = {
   DAOCreated: 'DAOCreated',
   Granted: 'Granted',
   Revoked: 'Revoked',
-  EXECUTED: 'Executed',
+  Executed: 'Executed',
 };
 
 const MODIFY_VOTE_CONFIG = ethers.utils.id('MODIFY_VOTE_CONFIG');
@@ -249,7 +249,7 @@ describe('DAOFactory: ', function () {
     await voting.newVote('0x', actions, 0, 0, false, VoterState.Yea);
 
     expect(await voting.vote(0, VoterState.Yea, true))
-      .to.emit(dao, EVENTS.EXECUTED)
+      .to.emit(dao, EVENTS.Executed)
       .withArgs(voting.address, 0, [], [])
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(3, 4, 5);
@@ -379,7 +379,7 @@ describe('DAOFactory: ', function () {
     await voting.newVote('0x', actions, 0, 0, false, VoterState.Yea);
 
     expect(await voting.vote(0, VoterState.Yea, true))
-      .to.emit(dao, EVENTS.EXECUTED)
+      .to.emit(dao, EVENTS.Executed)
       .withArgs(voting.address, 0, [], [])
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(3, 4, 5);

--- a/packages/contracts/test/dao-factory.ts
+++ b/packages/contracts/test/dao-factory.ts
@@ -7,7 +7,7 @@ import { customError } from './test-utils/custom-error-helper';
 
 const EVENTS = {
   NewDAORegistered: 'NewDAORegistered',
-  SetMetadata: 'SetMetadata',
+  MetadataSet: 'MetadataSet',
   UpdateConfig: 'UpdateConfig',
   DAOCreated: 'DAOCreated',
   Granted: 'Granted',
@@ -172,7 +172,7 @@ describe('DAOFactory: ', function () {
 
     // Check if correct ACL events are thrown.
     tx = tx.to
-      .emit(dao, EVENTS.SetMetadata)
+      .emit(dao, EVENTS.MetadataSet)
       .withArgs(daoDummyMetadata)
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(
@@ -294,7 +294,7 @@ describe('DAOFactory: ', function () {
 
     // Check if correct ACL events are thrown.
     tx = tx.to
-      .emit(dao, EVENTS.SetMetadata)
+      .emit(dao, EVENTS.MetadataSet)
       .withArgs(daoDummyMetadata)
       .to.emit(voting, EVENTS.UpdateConfig)
       .withArgs(

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed the event `SetMetadata` to `MetadataSet`
 - Updated Subgraph to adapt to the changes in the core contracts.
 - Refactored subgraph's unit testing, applying clean code standards.
 

--- a/packages/subgraph/manifest/subgraph.placeholder.yaml
+++ b/packages/subgraph/manifest/subgraph.placeholder.yaml
@@ -54,8 +54,8 @@ templates:
         - name: ERC165
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/core/erc165/ERC165.sol/ERC165.json
       eventHandlers:
-        - event: SetMetadata(bytes)
-          handler: handleSetMetadata
+        - event: MetadataSet(bytes)
+          handler: handleMetadataSet
         - event: Deposited(indexed address,indexed address,uint256,string)
           handler: handleDeposited
         - event: ETHDeposited(address,uint256)

--- a/packages/subgraph/src/dao/dao.ts
+++ b/packages/subgraph/src/dao/dao.ts
@@ -1,6 +1,6 @@
 import {
   DAO as DAOContract,
-  SetMetadata,
+  MetadataSet,
   Executed,
   Deposited,
   ETHDeposited,
@@ -21,13 +21,13 @@ import {addPackage, decodeWithdrawParams, removePackage} from './utils';
 import {handleERC20Token, updateBalance} from '../utils/tokens';
 import {handleMetadata} from '../utils/metadata';
 
-export function handleSetMetadata(event: SetMetadata): void {
+export function handleMetadataSet(event: MetadataSet): void {
   let daoId = event.address.toHexString();
   let metadata = handleMetadata(event.params.metadata.toString());
-  _handleSetMetadata(daoId, metadata);
+  _handleMetadataSet(daoId, metadata);
 }
 
-export function _handleSetMetadata(daoId: string, metadata: string): void {
+export function _handleMetadataSet(daoId: string, metadata: string): void {
   let entity = Dao.load(daoId);
   if (entity) {
     entity.metadata = metadata;

--- a/packages/subgraph/tests/dao/dao.test.ts
+++ b/packages/subgraph/tests/dao/dao.test.ts
@@ -20,12 +20,12 @@ import {
   handleETHDeposited,
   handleDeposited,
   handleExecuted,
-  _handleSetMetadata
+  _handleMetadataSet
 } from '../../src/dao/dao';
 import {createDummyAcctions, createTokenCalls} from '../utils';
 import {Dao, ERC20VotingProposal} from '../../generated/schema';
 
-test('Run dao (handleSetMetadata) mappings with mock event', () => {
+test('Run dao (handleMetadataSet) mappings with mock event', () => {
   // create state
   let daoEntity = new Dao(Address.fromHexString(DAO_ADDRESS).toHexString());
   daoEntity.save();
@@ -35,7 +35,7 @@ test('Run dao (handleSetMetadata) mappings with mock event', () => {
   let entityID = Address.fromString(DAO_ADDRESS).toHexString();
 
   // handle event
-  _handleSetMetadata(entityID, metadata);
+  _handleMetadataSet(entityID, metadata);
 
   // checks
   assert.fieldEquals('Dao', entityID, 'id', entityID);

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -1,7 +1,7 @@
 import {ethereum, Bytes, Address, BigInt} from '@graphprotocol/graph-ts';
 import {createMockedFunction, newMockEvent} from 'matchstick-as/assembly/index';
 import {
-  SetMetadata,
+  MetadataSet,
   ETHDeposited,
   Deposited,
   Granted,
@@ -12,23 +12,23 @@ import {
 
 // events
 
-export function createNewSetMetadataEvent(
+export function createNewMetadataSetEvent(
   metadata: string,
   contractAddress: string
-): SetMetadata {
-  let newSetMetadataEvent = changetype<SetMetadata>(newMockEvent());
+): MetadataSet {
+  let newMetadataSetEvent = changetype<MetadataSet>(newMockEvent());
 
-  newSetMetadataEvent.address = Address.fromString(contractAddress);
-  newSetMetadataEvent.parameters = [];
+  newMetadataSetEvent.address = Address.fromString(contractAddress);
+  newMetadataSetEvent.parameters = [];
 
   let metadataParam = new ethereum.EventParam(
     'metadata',
     ethereum.Value.fromBytes(Bytes.fromUTF8(metadata))
   );
 
-  newSetMetadataEvent.parameters.push(metadataParam);
+  newMetadataSetEvent.parameters.push(metadataParam);
 
-  return newSetMetadataEvent;
+  return newMetadataSetEvent;
 }
 
 export function createNewETHDepositedEvent(


### PR DESCRIPTION
## Description

Task: [APP-290](https://aragonassociation.atlassian.net/browse/APP-290)

Similar to the `hasPermission()` functionality of the ACL, also other publicly visible methods, that make up the DAO (e.g. ERC1271) should be part of the `IDAO` interface to be used in `Component` and `MetaTxComponent`. 
Accordingly, `trustedForwarder()`, `isValidSignature()`, and other methods should be part of the `IDAO` interface to be used in `Component` and `MetaTxComponent` so that things are uniform.
If we want to redesign at a later point, this makes it easier.

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.