### PR TITLE
Fix npm release and writeback deployed npm versions

### DIFF
--- a/.github/workflows/npm-release-reusable.yml
+++ b/.github/workflows/npm-release-reusable.yml
@@ -38,12 +38,13 @@ jobs:
   build_deploy:
     runs-on: ubuntu-latest
     needs: [prepare]
-    if: ${{ needs.prepare.outputs.bump }} != 'pre' && ${{ needs.prepare.outputs.bump }} != ''
+    if: ${{ needs.prepare.outputs.bump != 'pre' }}
     strategy:
       fail-fast: false
       matrix:
         package: [contracts, contracts-ethers]
     steps:
+      - run: echo ${{ needs.prepare.outputs.bump }}
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.ref }}
@@ -63,3 +64,4 @@ jobs:
           yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      

--- a/.github/workflows/npm-release-reusable.yml
+++ b/.github/workflows/npm-release-reusable.yml
@@ -44,7 +44,6 @@ jobs:
       matrix:
         package: [contracts, contracts-ethers]
     steps:
-      - run: echo ${{ needs.prepare.outputs.bump }}
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.ref }}
@@ -64,4 +63,35 @@ jobs:
           yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.package}}
+          path: ./packages/${{ matrix.package }}/
+          retention-days: 1
+  pushChanges:
+    runs-on: ubuntu-latest
+    needs: [build_deploy]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.ARABOT_PAT }}
+      - uses: actions/download-artifact@v3
+        with:
+          path: packages/contracts/
+          name: contracts
+      - uses: actions/download-artifact@v3
+        with:
+          path: packages/contracts-ethers/
+          name: contracts-ethers
+      - name: Commit changes
+        id: commit
+        run: |
+          git fetch
+          git pull
+          git config --global user.name "Arabot-1"
+          git config --global user.email "arabot-1@users.noreply.github.com"
+          git add packages/contracts/package.json
+          git add packages/contracts-ethers/package.json
+          git commit -am "Updates package.json versions"
+          git push


### PR DESCRIPTION
## Description

- Fixes bug in `npm-release-reusable.yml` workflow which runs when it shouldn't
- Adds feature to write back the package.json of the packages `contracts` and `contracts-ethers` when a new version is published

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.