### PR TITLE
Refactoring of event names and NatSpec comments

### DIFF
--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -47,10 +47,6 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     /// @notice Thrown if an ETH withdraw fails
     error ETHWithdrawFailed();
 
-    /// @notice Emmited when setting a new TrustedForwarder on the DAO
-    /// @param forwarder the new forwarder address
-    event TrustedForwarderSet(address forwarder);
-
     /// @dev Used for UUPS upgradability pattern
     /// @param _metadata IPFS hash that points to all the metadata (logo, description, tags, etc.) of a DAO
     function initialize(

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -202,12 +202,12 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     }
 
     /// @notice Emits the MetadataSet event if new metadata is set
-    /// @param _metadata Hash of the IPFS file object 
+    /// @param _metadata Hash of the IPFS file object
     function _setMetadata(bytes calldata _metadata) internal {
         emit MetadataSet(_metadata);
     }
 
-    /// @notice Set trusted forwarder on the DAO and emits the event
+    /// @notice Sets the trusted forwarder on the DAO and emits the associated event
     /// @param _forwarder Address of the forwarder
     function _setTrustedForwarder(address _forwarder) internal {
         _trustedForwarder = _forwarder;

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -40,12 +40,16 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     error ZeroAmount();
 
     /// @notice Thrown if the expected and actually deposited ETH amount mismatch
-    /// @param expected ETH amount
-    /// @param actual ETH amount
+    /// @param expected ETH expected amount
+    /// @param actual ETH actual amount
     error ETHDepositAmountMismatch(uint256 expected, uint256 actual);
 
     /// @notice Thrown if an ETH withdraw fails
     error ETHWithdrawFailed();
+
+    /// @notice Emmited when setting a new TrustedForwarder on the DAO
+    /// @param forwarder the new forwarder address
+    event TrustedForwarderSet(address forwarder);
 
     /// @dev Used for UUPS upgradability pattern
     /// @param _metadata IPFS hash that points to all the metadata (logo, description, tags, etc.) of a DAO
@@ -103,7 +107,12 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         _setMetadata(_metadata);
     }
 
-    /// @inheritdoc IDAO
+    /// @notice If called, the list of provided actions will be executed.
+    /// @dev It run a loop through the array of acctions and execute one by one.
+    /// @dev If one acction fails, all will be reverted.
+    /// @param callId The id of the call
+    /// @dev The value of callId is defined by the component/contract calling execute. It can be used, for example, as a nonce.
+    /// @param _actions The array of actions
     function execute(uint256 callId, Action[] memory _actions)
         external
         override
@@ -196,10 +205,14 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         _handleCallback(msg.sig, msg.data); // WARN: does a low-level return, any code below would be unreacheable
     }
 
+    /// @notice Method that emmits the MetadataSet event when a new metadata is set
+    /// @param _metadata Hash of the IPFS file object 
     function _setMetadata(bytes calldata _metadata) internal {
         emit MetadataSet(_metadata);
     }
 
+    /// @notice set trusted forwarder on the DAO and emits the event
+    /// @param _forwarder address of the forwarder
     function _setTrustedForwarder(address _forwarder) internal {
         _trustedForwarder = _forwarder;
 

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -40,8 +40,8 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     error ZeroAmount();
 
     /// @notice Thrown if the expected and actually deposited ETH amount mismatch
-    /// @param expected ETH expected amount
-    /// @param actual ETH actual amount
+    /// @param expected Expected ETH amount
+    /// @param actual Actual ETH amount
     error ETHDepositAmountMismatch(uint256 expected, uint256 actual);
 
     /// @notice Thrown if an ETH withdraw fails
@@ -104,8 +104,8 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
     }
 
     /// @notice If called, the list of provided actions will be executed.
-    /// @dev It run a loop through the array of acctions and execute one by one.
-    /// @dev If one acction fails, all will be reverted.
+    /// @dev It runs a loop through the array of actions and executes them one by one.
+    /// @dev If one action fails, all will be reverted.
     /// @param callId The id of the call
     /// @dev The value of callId is defined by the component/contract calling execute. It can be used, for example, as a nonce.
     /// @param _actions The array of actions
@@ -191,7 +191,7 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         return signatureValidator.isValidSignature(_hash, _signature); // forward call to set validation contract
     }
 
-    /// @dev Emit ETHDeposited event to track ETH deposits that weren't done over the deposit method.
+    /// @dev Emits ETHDeposited event to track ETH deposits that weren't done over the deposit method.
     receive() external payable {
         emit ETHDeposited(msg.sender, msg.value);
     }
@@ -201,14 +201,14 @@ contract DAO is IDAO, Initializable, UUPSUpgradeable, ACL, ERC1271, AdaptiveERC1
         _handleCallback(msg.sig, msg.data); // WARN: does a low-level return, any code below would be unreacheable
     }
 
-    /// @notice Method that emmits the MetadataSet event when a new metadata is set
+    /// @notice Emits the MetadataSet event if new metadata is set
     /// @param _metadata Hash of the IPFS file object 
     function _setMetadata(bytes calldata _metadata) internal {
         emit MetadataSet(_metadata);
     }
 
-    /// @notice set trusted forwarder on the DAO and emits the event
-    /// @param _forwarder address of the forwarder
+    /// @notice Set trusted forwarder on the DAO and emits the event
+    /// @param _forwarder Address of the forwarder
     function _setTrustedForwarder(address _forwarder) internal {
         _trustedForwarder = _forwarder;
 

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -31,6 +31,8 @@ abstract contract IDAO {
     /// @param _metadata The IPFS hash of the new metadata object
     function setMetadata(bytes calldata _metadata) external virtual;
 
+    /// @dev Emitted when the DAO metadata is updated
+    /// @param metadata The IPFS hash of the new metadata object
     event MetadataSet(bytes metadata);
 
     /// @notice If called, the list of provided actions will be executed.
@@ -42,6 +44,13 @@ abstract contract IDAO {
         virtual
         returns (bytes[] memory);
 
+    /// @notice Emitted when a proposal is executed
+    /// @param actor The address of the caller
+    /// @param callId The id of the call
+    /// @dev The value of callId is defined by the component/contract calling the execute function. 
+    ///      A Component implementation can use it, for example, as a nonce.
+    /// @param actions Array of actions executed
+    /// @param execResults Array with the results of the executed actions
     event Executed(address indexed actor, uint256 callId, Action[] actions, bytes[] execResults);
 
     /// @notice Deposit ETH or any token to this contract with a reference string
@@ -55,23 +64,35 @@ abstract contract IDAO {
         string calldata _reference
     ) external payable virtual;
 
+    /// @notice Emitted when a deposit is made
+    /// @param sender The address of the sender
+    /// @param token The address of the token deposited
+    /// @param amount The amount of tokens deposited
+    /// @param _reference The deposit reference desribing the reason of it
     event Deposited(
         address indexed sender,
         address indexed token,
         uint256 amount,
         string _reference
     );
-    // ETHDeposited and Deposited are both needed. ETHDeposited makes sure that whoever sends funds
-    // with `send/transfer`, receive function can still be executed without reverting due to gas cost
-    // increases in EIP-2929. To still use `send/transfer`, access list is needed that has the address
-    // of the contract(base contract) that is behind the proxy.
+
+    /**
+     *  @dev ETHDeposited and Deposited are both needed. ETHDeposited makes sure that whoever sends funds
+     *  with `send/transfer`, receive function can still be executed without reverting due to gas cost
+     *  increases in EIP-2929. To still use `send/transfer`, access list is needed that has the address
+     *  of the contract(base contract) that is behind the proxy.
+     *
+     *  @notice Emitted when ETH is deposited
+     *  @param sender The address of the sender
+     *  @param amount The amount of ETH deposited
+     */ 
     event ETHDeposited(address sender, uint256 amount);
 
     /// @notice Withdraw tokens or ETH from the DAO with a withdraw reference string
     /// @param _token The address of the token and in case of ETH address(0)
     /// @param _to The target address to send tokens or ETH
     /// @param _amount The amount of tokens to deposit
-    /// @param _reference The deposit reference describing the reason of it
+    /// @param _reference The withdraw reference describing the reason of it
     function withdraw(
         address _token,
         address _to,
@@ -79,6 +100,11 @@ abstract contract IDAO {
         string memory _reference
     ) external virtual;
 
+    /// @notice Emitted when a withdraw is done
+    /// @param token The address of the token withdrawn
+    /// @param to The address of the withdrawer 
+    /// @param amount The amount of tokens withdrawn
+    /// @param _reference The withdraw reference describing the reason of it
     event Withdrawn(address indexed token, address indexed to, uint256 amount, string _reference);
 
     /// @notice Setter for the trusted forwarder verifying the meta transaction

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -116,6 +116,8 @@ abstract contract IDAO {
     /// @return the trusted forwarder address
     function trustedForwarder() external virtual returns (address);
 
+    /// @notice Emmited when setting a new TrustedForwarder on the DAO
+    /// @param forwarder the new forwarder address
     event TrustedForwarderSet(address forwarder);
 
     /// @notice Setter to set the signature validator contract of ERC1271

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -91,7 +91,7 @@ abstract contract IDAO {
     /// @notice Withdraw tokens or ETH from the DAO with a withdraw reference string
     /// @param _token The address of the token and in case of ETH address(0)
     /// @param _to The target address to send tokens or ETH
-    /// @param _amount The amount of tokens to deposit
+    /// @param _amount The amount of tokens to withdraw
     /// @param _reference The withdraw reference describing the reason of it
     function withdraw(
         address _token,

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -47,7 +47,7 @@ abstract contract IDAO {
     /// @notice Emitted when a proposal is executed
     /// @param actor The address of the caller
     /// @param callId The id of the call
-    /// @dev The value of callId is defined by the component/contract calling the execute function. 
+    /// @dev The value of callId is defined by the component/contract calling the execute function.
     ///      A Component implementation can use it, for example, as a nonce.
     /// @param actions Array of actions executed
     /// @param execResults Array with the results of the executed actions
@@ -57,7 +57,7 @@ abstract contract IDAO {
     /// @dev Deposit ETH (token address == 0) or any token with a reference
     /// @param _token The address of the token and in case of ETH address(0)
     /// @param _amount The amount of tokens to deposit
-    /// @param _reference The deposit reference describing the reason of it
+    /// @param _reference The reference describing the deposit reason
     function deposit(
         address _token,
         uint256 _amount,
@@ -68,7 +68,7 @@ abstract contract IDAO {
     /// @param sender The address of the sender
     /// @param token The address of the token deposited
     /// @param amount The amount of tokens deposited
-    /// @param _reference The deposit reference desribing the reason of it
+    /// @param _reference The reference describing the deposit reason
     event Deposited(
         address indexed sender,
         address indexed token,
@@ -76,11 +76,11 @@ abstract contract IDAO {
         string _reference
     );
 
-    /// @dev ETHDeposited and Deposited are both needed. ETHDeposited makes sure that whoever sends funds
-    ///      with `send/transfer`, receive function can still be executed without reverting due to gas cost
-    ///      increases in EIP-2929. To still use `send/transfer`, access list is needed that has the address
-    ///      of the contract(base contract) that is behind the proxy.
     /// @notice Emitted when ETH is deposited
+    /// @dev `ETHDeposited` and `Deposited` are both needed. `ETHDeposited` makes sure that whoever sends funds
+    ///      with `send`/`transfer`, receive function can still be executed without reverting due to gas cost
+    ///      increases in EIP-2929. To still use `send`/`transfer`, access list is needed that has the address
+    ///      of the contract(base contract) that is behind the proxy.
     /// @param sender The address of the sender
     /// @param amount The amount of ETH deposited
     event ETHDeposited(address sender, uint256 amount);
@@ -99,7 +99,7 @@ abstract contract IDAO {
 
     /// @notice Emitted when a withdraw is done
     /// @param token The address of the token withdrawn
-    /// @param to The address of the withdrawer 
+    /// @param to The address of the withdrawer
     /// @param amount The amount of tokens withdrawn
     /// @param _reference The reference describing the withdrawal reason
     event Withdrawn(address indexed token, address indexed to, uint256 amount, string _reference);

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -36,8 +36,8 @@ abstract contract IDAO {
     event MetadataSet(bytes metadata);
 
     /// @notice If called, the list of provided actions will be executed.
-    /// @dev It run a loop through the array of acctions and execute one by one.
-    /// @dev If one acction fails, all will be reverted.
+    /// @dev It runs a loop through the array of actions and execute them one by one.
+    /// @dev If one action fails, all will be reverted.
     /// @param _actions The aray of actions
     function execute(uint256 callId, Action[] memory _actions)
         external
@@ -76,23 +76,20 @@ abstract contract IDAO {
         string _reference
     );
 
-    /**
-     *  @dev ETHDeposited and Deposited are both needed. ETHDeposited makes sure that whoever sends funds
-     *  with `send/transfer`, receive function can still be executed without reverting due to gas cost
-     *  increases in EIP-2929. To still use `send/transfer`, access list is needed that has the address
-     *  of the contract(base contract) that is behind the proxy.
-     *
-     *  @notice Emitted when ETH is deposited
-     *  @param sender The address of the sender
-     *  @param amount The amount of ETH deposited
-     */ 
+    /// @dev ETHDeposited and Deposited are both needed. ETHDeposited makes sure that whoever sends funds
+    ///      with `send/transfer`, receive function can still be executed without reverting due to gas cost
+    ///      increases in EIP-2929. To still use `send/transfer`, access list is needed that has the address
+    ///      of the contract(base contract) that is behind the proxy.
+    /// @notice Emitted when ETH is deposited
+    /// @param sender The address of the sender
+    /// @param amount The amount of ETH deposited
     event ETHDeposited(address sender, uint256 amount);
 
     /// @notice Withdraw tokens or ETH from the DAO with a withdraw reference string
     /// @param _token The address of the token and in case of ETH address(0)
     /// @param _to The target address to send tokens or ETH
     /// @param _amount The amount of tokens to withdraw
-    /// @param _reference The withdraw reference describing the reason of it
+    /// @param _reference The reference describing the withdrawal reason
     function withdraw(
         address _token,
         address _to,
@@ -104,19 +101,19 @@ abstract contract IDAO {
     /// @param token The address of the token withdrawn
     /// @param to The address of the withdrawer 
     /// @param amount The amount of tokens withdrawn
-    /// @param _reference The withdraw reference describing the reason of it
+    /// @param _reference The reference describing the withdrawal reason
     event Withdrawn(address indexed token, address indexed to, uint256 amount, string _reference);
 
     /// @notice Setter for the trusted forwarder verifying the meta transaction
-    /// @param _trustedForwarder the trusted forwarder address
-    /// @dev used to update the trusted forwarder
+    /// @param _trustedForwarder The trusted forwarder address
+    /// @dev Used to update the trusted forwarder
     function setTrustedForwarder(address _trustedForwarder) external virtual;
 
     /// @notice Setter for the trusted forwarder verifying the meta transaction
-    /// @return the trusted forwarder address
+    /// @return The trusted forwarder address
     function trustedForwarder() external virtual returns (address);
 
-    /// @notice Emmited when setting a new TrustedForwarder on the DAO
+    /// @notice Emitted when setting a new TrustedForwarder on the DAO
     /// @param forwarder the new forwarder address
     event TrustedForwarderSet(address forwarder);
 
@@ -124,7 +121,7 @@ abstract contract IDAO {
     /// @param _signatureValidator ERC1271 SignatureValidator
     function setSignatureValidator(address _signatureValidator) external virtual;
 
-    /// @notice Method to validate the signature as described in ERC1271
+    /// @notice Validates the signature as described in ERC1271
     /// @param _hash Hash of the data to be signed
     /// @param _signature Signature byte array associated with _hash
     /// @return bytes4

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -13,7 +13,7 @@ abstract contract IDAO {
         bytes data; // FuncSig + arguments
     }
 
-    /// @dev Required to handle the permissions within the whole DAO framework accordingly
+    /// @notice Required to handle the permissions within the whole DAO framework accordingly
     /// @param _where The address of the contract
     /// @param _who The address of a EOA or contract to give the permissions
     /// @param _role The hash of the role identifier
@@ -31,7 +31,7 @@ abstract contract IDAO {
     /// @param _metadata The IPFS hash of the new metadata object
     function setMetadata(bytes calldata _metadata) external virtual;
 
-    /// @dev Emitted when the DAO metadata is updated
+    /// @notice Emitted when the DAO metadata is updated
     /// @param metadata The IPFS hash of the new metadata object
     event MetadataSet(bytes metadata);
 

--- a/packages/contracts/contracts/core/acl/ACL.sol
+++ b/packages/contracts/contracts/core/acl/ACL.sol
@@ -63,6 +63,13 @@ contract ACL is Initializable {
     mapping(bytes32 => bool) internal freezePermissions;
 
     // Events
+
+    /// @notice Emitted when a new permission `role` is granted to the address `actor` by the address `who` in the contract `where`
+    /// @param role The hash of the role identifier
+    /// @param actor The address receiving the new role
+    /// @param who The address (EOA or contract) owning the permission
+    /// @param where The address of the contract    
+    /// @param oracle The ACLOracle to be used or it is just the ALLOW_FLAG
     event Granted(
         bytes32 indexed role,
         address indexed actor,
@@ -70,7 +77,18 @@ contract ACL is Initializable {
         address where,
         IACLOracle oracle
     );
+
+    /// @notice Emitted when a new permission `role` is revoked to the address `actor` by the address `who` in the contract `where`
+    /// @param role The hash of the role identifier
+    /// @param actor The address receiving the revoked role
+    /// @param who The address (EOA or contract) owning the permission
+    /// @param where The address of the contract
     event Revoked(bytes32 indexed role, address indexed actor, address indexed who, address where);
+    
+    /// @notice Emitted when a `role` is frozen to the address `actor` by the contract `where`
+    /// @param role The hash of the role identifier
+    /// @param actor The address that is frozen
+    /// @param where The address of the contract
     event Frozen(bytes32 indexed role, address indexed actor, address where);
 
     /// @dev The modifier used within the DAO framework to check permissions.

--- a/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
+++ b/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
@@ -7,10 +7,10 @@ import "./ERC165.sol";
 /// @title AdaptiveERC165
 /// @author Aragon Association - 2022
 contract AdaptiveERC165 is ERC165 {
-    /// @dev ERC165 interface ID -> whether it is supported
+    /// @notice ERC165 interface ID -> whether it is supported
     mapping(bytes4 => bool) internal standardSupported;
 
-    /// @dev Callback function signature -> magic number to return
+    /// @notice Callback function signature -> magic number to return
     mapping(bytes4 => bytes32) internal callbackMagicNumbers;
 
     bytes32 internal constant UNREGISTERED_CALLBACK = bytes32(0);
@@ -20,22 +20,22 @@ contract AdaptiveERC165 is ERC165 {
 
     // Events
 
-    /// @dev Emmitted when a new standard is registred and assigned to `interfaceId`
+    /// @notice Emmitted when a new standard is registred and assigned to `interfaceId`
     event StandardRegistered(bytes4 interfaceId);
 
-    /// @dev Emmitted when a callback is registered
+    /// @notice Emmitted when a callback is registered
     event CallbackRegistered(bytes4 sig, bytes4 magicNumber);
 
-    /// @dev Emmitted when a callback is received
+    /// @notice Emmitted when a callback is received
     event CallbackReceived(bytes4 indexed sig, bytes data);
 
-    /// @dev Method to check if the contract supports a specific interface or not
+    /// @notice Method to check if the contract supports a specific interface or not
     /// @param _interfaceId The identifier of the interface to check for
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return standardSupported[_interfaceId] || super.supportsInterface(_interfaceId);
     }
 
-    /// @dev This method is existing to be able to support future versions of the ERC165 or similar without upgrading the contracts.
+    /// @notice This method is existing to be able to support future versions of the ERC165 or similar without upgrading the contracts.
     /// @param _sig The function signature of the called method. (msg.sig)
     /// @param _data The data resp. arguments passed to the method
     function _handleCallback(bytes4 _sig, bytes memory _data) internal {
@@ -52,7 +52,7 @@ contract AdaptiveERC165 is ERC165 {
         }
     }
 
-    /// @dev Registers a standard and also callback
+    /// @notice Registers a standard and also callback
     /// @param _interfaceId The identifier of the interface to check for
     /// @param _callbackSig The function signature of the called method. (msg.sig)
     /// @param _magicNumber The data resp. arguments passed to the method
@@ -65,14 +65,14 @@ contract AdaptiveERC165 is ERC165 {
         _registerCallback(_callbackSig, _magicNumber);
     }
 
-    /// @dev Registers a standard resp. interface type
+    /// @notice Registers a standard resp. interface type
     /// @param _interfaceId The identifier of the interface to check for
     function _registerStandard(bytes4 _interfaceId) internal {
         standardSupported[_interfaceId] = true;
         emit StandardRegistered(_interfaceId);
     }
 
-    /// @dev Registers a callback
+    /// @notice Registers a callback
     /// @param _callbackSig The function signature of the called method. (msg.sig)
     /// @param _magicNumber The data resp. arguments passed to the method
     function _registerCallback(bytes4 _callbackSig, bytes4 _magicNumber) internal {

--- a/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
+++ b/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
@@ -29,14 +29,14 @@ contract AdaptiveERC165 is ERC165 {
     /// @notice Emmitted when a callback is received
     event CallbackReceived(bytes4 indexed sig, bytes data);
 
-    /// @notice Method to check if the contract supports a specific interface or not
+    /// @notice Checks if the contract supports a specific interface or not
     /// @param _interfaceId The identifier of the interface to check for
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return standardSupported[_interfaceId] || super.supportsInterface(_interfaceId);
     }
 
-    /// @notice This method is existing to be able to support future versions of the ERC165 or similar without upgrading the contracts.
-    /// @param _sig The function signature of the called method. (msg.sig)
+    /// @notice Handles callbacks to support future versions of the ERC165 or similar without upgrading the contracts.
+    /// @param _sig The function signature of the called method (msg.sig)
     /// @param _data The data resp. arguments passed to the method
     function _handleCallback(bytes4 _sig, bytes memory _data) internal {
         bytes32 magicNumber = callbackMagicNumbers[_sig];
@@ -54,8 +54,8 @@ contract AdaptiveERC165 is ERC165 {
 
     /// @notice Registers a standard and also callback
     /// @param _interfaceId The identifier of the interface to check for
-    /// @param _callbackSig The function signature of the called method. (msg.sig)
-    /// @param _magicNumber The data resp. arguments passed to the method
+    /// @param _callbackSig The function signature of the called method (msg.sig)
+    /// @param _magicNumber The magic number to be registered for the function signature
     function _registerStandardAndCallback(
         bytes4 _interfaceId,
         bytes4 _callbackSig,
@@ -73,8 +73,8 @@ contract AdaptiveERC165 is ERC165 {
     }
 
     /// @notice Registers a callback
-    /// @param _callbackSig The function signature of the called method. (msg.sig)
-    /// @param _magicNumber The data resp. arguments passed to the method
+    /// @param _callbackSig The function signature of the called method (msg.sig)
+    /// @param _magicNumber The magic number to be registered for the function signature
     function _registerCallback(bytes4 _callbackSig, bytes4 _magicNumber) internal {
         callbackMagicNumbers[_callbackSig] = _magicNumber;
         emit CallbackRegistered(_callbackSig, _magicNumber);

--- a/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
+++ b/packages/contracts/contracts/core/erc165/AdaptiveERC165.sol
@@ -19,9 +19,15 @@ contract AdaptiveERC165 is ERC165 {
     error AdapERC165UnkownCallback(bytes32 magicNumber);
 
     // Events
-    event RegisteredStandard(bytes4 interfaceId);
-    event RegisteredCallback(bytes4 sig, bytes4 magicNumber);
-    event ReceivedCallback(bytes4 indexed sig, bytes data);
+
+    /// @dev Emmitted when a new standard is registred and assigned to `interfaceId`
+    event StandardRegistered(bytes4 interfaceId);
+
+    /// @dev Emmitted when a callback is registered
+    event CallbackRegistered(bytes4 sig, bytes4 magicNumber);
+
+    /// @dev Emmitted when a callback is received
+    event CallbackReceived(bytes4 indexed sig, bytes data);
 
     /// @dev Method to check if the contract supports a specific interface or not
     /// @param _interfaceId The identifier of the interface to check for
@@ -37,7 +43,7 @@ contract AdaptiveERC165 is ERC165 {
         if (magicNumber == UNREGISTERED_CALLBACK)
             revert AdapERC165UnkownCallback({magicNumber: magicNumber});
 
-        emit ReceivedCallback(_sig, _data);
+        emit CallbackReceived(_sig, _data);
 
         // low-level return magic number
         assembly {
@@ -63,7 +69,7 @@ contract AdaptiveERC165 is ERC165 {
     /// @param _interfaceId The identifier of the interface to check for
     function _registerStandard(bytes4 _interfaceId) internal {
         standardSupported[_interfaceId] = true;
-        emit RegisteredStandard(_interfaceId);
+        emit StandardRegistered(_interfaceId);
     }
 
     /// @dev Registers a callback
@@ -71,6 +77,6 @@ contract AdaptiveERC165 is ERC165 {
     /// @param _magicNumber The data resp. arguments passed to the method
     function _registerCallback(bytes4 _callbackSig, bytes4 _magicNumber) internal {
         callbackMagicNumbers[_callbackSig] = _magicNumber;
-        emit RegisteredCallback(_callbackSig, _magicNumber);
+        emit CallbackRegistered(_callbackSig, _magicNumber);
     }
 }

--- a/packages/contracts/contracts/factory/DAOFactory.sol
+++ b/packages/contracts/contracts/factory/DAOFactory.sol
@@ -60,7 +60,7 @@ contract DAOFactory {
 
     /// @dev Creates a new DAO with ERC20 based voting. It also will deploy a new token if the corresponding config is passed.
     /// @param _daoConfig The name and metadata hash of the DAO it creates
-    /// @param _votingSettings The majority voting configs and minimum duration of voting
+    /// @param _voteConfig The majority voting configs and minimum duration of voting
     /// @param _tokenConfig The token config used to deploy a new token
     /// @param _mintConfig The config for the minter for the newly created token
     /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
@@ -105,7 +105,7 @@ contract DAOFactory {
 
     /// @dev Creates a new DAO with whitelist based voting.
     /// @param _daoConfig The name and metadata hash of the DAO it creates
-    /// @param _votingSettings The majority voting configs and minimum duration of voting
+    /// @param _voteConfig The majority voting configs and minimum duration of voting
     /// @param _whitelistVoters A array of addresses that are allowed to vote
     /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
     function newWhitelistVotingDAO(
@@ -172,7 +172,7 @@ contract DAOFactory {
     /// @dev internal helper method to create ERC20Voting
     /// @param _dao The DAO address
     /// @param _token The ERC20 Upgradeable token address
-    /// @param _votingSettings The ERC20 voting settings for the DAO
+    /// @param _voteConfig The ERC20 voting settings for the DAO
     function createERC20Voting(
         DAO _dao,
         ERC20VotesUpgradeable _token,
@@ -217,7 +217,7 @@ contract DAOFactory {
     /// @dev internal helper method to create Whitelist Voting
     /// @param _dao The DAO address creating the Whitelist Voting
     /// @param _whitelistVoters The array of the allowed voting addresses
-    /// @param _votingSettings The array with the voting settings
+    /// @param _voteConfig The voting settings
     function createWhitelistVoting(
         DAO _dao,
         address[] calldata _whitelistVoters,

--- a/packages/contracts/contracts/factory/DAOFactory.sol
+++ b/packages/contracts/contracts/factory/DAOFactory.sol
@@ -42,11 +42,15 @@ contract DAOFactory {
         uint64 minDuration;
     }
 
+    /// @notice Emitted when a new DAO is created
+    /// @param name DAO name
+    /// @param token ERC20 DAO token address or address(0) no token was created
+    /// @param voting The address of the voting component of the new DAO
     event DAOCreated(string name, address indexed token, address indexed voting);
 
-    // @dev Stores the registry and token factory address and creates the base contracts required for the factory
-    // @param _registry The DAO registry to register the DAO with his name
-    // @param _tokenFactory The Token Factory to register tokens
+    /// @dev Stores the registry and token factory address and creates the base contracts required for the factory
+    /// @param _registry The DAO registry to register the DAO with his name
+    /// @param _tokenFactory The Token Factory to register tokens
     constructor(Registry _registry, TokenFactory _tokenFactory) {
         registry = _registry;
         tokenFactory = _tokenFactory;
@@ -54,12 +58,12 @@ contract DAOFactory {
         setupBases();
     }
 
-    // @dev Creates a new DAO with ERC20 based voting. It also will deploy a new token if the corresponding config is passed.
-    // @oaram _daoConfig The name and metadata hash of the DAO it creates
-    // @param _voteConfig The majority voting configs and minimum duration of voting
-    // @param _tokenConfig The token config used to deploy a new token
-    // @param _mintConfig The config for the minter for the newly created token
-    // @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
+    /// @dev Creates a new DAO with ERC20 based voting. It also will deploy a new token if the corresponding config is passed.
+    /// @param _daoConfig The name and metadata hash of the DAO it creates
+    /// @param _votingSettings The majority voting configs and minimum duration of voting
+    /// @param _tokenConfig The token config used to deploy a new token
+    /// @param _mintConfig The config for the minter for the newly created token
+    /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
     function newERC20VotingDAO(
         DAOConfig calldata _daoConfig,
         VoteConfig calldata _voteConfig,
@@ -99,11 +103,11 @@ contract DAOFactory {
         emit DAOCreated(_daoConfig.name, address(token), address(voting));
     }
 
-    // @dev Creates a new DAO with whitelist based voting.
-    // @oaram _daoConfig The name and metadata hash of the DAO it creates
-    // @param _voteConfig The majority voting configs and minimum duration of voting
-    // @param _whitelisVoters A array of addresses that are allowed to vote
-    // @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
+    /// @dev Creates a new DAO with whitelist based voting.
+    /// @param _daoConfig The name and metadata hash of the DAO it creates
+    /// @param _votingSettings The majority voting configs and minimum duration of voting
+    /// @param _whitelistVoters A array of addresses that are allowed to vote
+    /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
     function newWhitelistVotingDAO(
         DAOConfig calldata _daoConfig,
         VoteConfig calldata _voteConfig,
@@ -122,9 +126,9 @@ contract DAOFactory {
         emit DAOCreated(_daoConfig.name, address(0), address(voting));
     }
 
-    // @dev Creates a new DAO.
-    // @oaram _daoConfig The name and metadata hash of the DAO it creates
-    // @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
+    /// @dev Creates a new DAO.
+    /// @param _daoConfig The name and metadata hash of the DAO it creates
+    /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
     function createDAO(DAOConfig calldata _daoConfig, address _gsnForwarder)
         internal
         returns (DAO dao)
@@ -135,9 +139,9 @@ contract DAOFactory {
         dao.initialize(_daoConfig.metadata, address(this), _gsnForwarder);
     }
 
-    // @dev Does set the required permissions for the new DAO.
-    // @param _dao The DAO instance just created.
-    // @param _voting The voting contract address (whitelist OR ERC20 voting)
+    /// @dev Does set the required permissions for the new DAO.
+    /// @param _dao The DAO instance just created.
+    /// @param _voting The voting contract address (whitelist OR ERC20 voting)
     function setDAOPermissions(DAO _dao, address _voting) internal {
         // set roles on the dao itself.
         ACLData.BulkItem[] memory items = new ACLData.BulkItem[](8);
@@ -166,6 +170,9 @@ contract DAOFactory {
     }
 
     /// @dev internal helper method to create ERC20Voting
+    /// @param _dao The DAO address
+    /// @param _token The ERC20 Upgradeable token address
+    /// @param _votingSettings The ERC20 voting settings for the DAO
     function createERC20Voting(
         DAO _dao,
         ERC20VotesUpgradeable _token,
@@ -208,6 +215,9 @@ contract DAOFactory {
     }
 
     /// @dev internal helper method to create Whitelist Voting
+    /// @param _dao The DAO address creating the Whitelist Voting
+    /// @param _whitelistVoters The array of the allowed voting addresses
+    /// @param _votingSettings The array with the voting settings
     function createWhitelistVoting(
         DAO _dao,
         address[] calldata _whitelistVoters,
@@ -254,7 +264,7 @@ contract DAOFactory {
         _dao.bulk(address(whitelistVoting), items);
     }
 
-    // @dev Internal helper method to set up the required base contracts on DAOFactory deployment.
+    /// @dev Internal helper method to set up the required base contracts on DAOFactory deployment.
     function setupBases() private {
         erc20VotingBase = address(new ERC20Voting());
         whitelistVotingBase = address(new WhitelistVoting());

--- a/packages/contracts/contracts/factory/DAOFactory.sol
+++ b/packages/contracts/contracts/factory/DAOFactory.sol
@@ -43,7 +43,7 @@ contract DAOFactory {
     }
 
     /// @notice Emitted when a new DAO is created
-    /// @param name DAO name
+    /// @param name The DAO name
     /// @param token ERC20 DAO token address or address(0) no token was created
     /// @param voting The address of the voting component of the new DAO
     event DAOCreated(string name, address indexed token, address indexed voting);
@@ -106,7 +106,7 @@ contract DAOFactory {
     /// @dev Creates a new DAO with whitelist based voting.
     /// @param _daoConfig The name and metadata hash of the DAO it creates
     /// @param _voteConfig The majority voting configs and minimum duration of voting
-    /// @param _whitelistVoters A array of addresses that are allowed to vote
+    /// @param _whitelistVoters An array of addresses that are allowed to vote
     /// @param _gsnForwarder The forwarder address for the OpenGSN meta tx solution
     function newWhitelistVotingDAO(
         DAOConfig calldata _daoConfig,
@@ -169,7 +169,7 @@ contract DAOFactory {
         _dao.bulk(address(_dao), items);
     }
 
-    /// @dev internal helper method to create ERC20Voting
+    /// @dev Internal helper method to create ERC20Voting
     /// @param _dao The DAO address
     /// @param _token The ERC20 Upgradeable token address
     /// @param _voteConfig The ERC20 voting settings for the DAO
@@ -214,7 +214,7 @@ contract DAOFactory {
         _dao.bulk(address(erc20Voting), items);
     }
 
-    /// @dev internal helper method to create Whitelist Voting
+    /// @dev Internal helper method to create Whitelist Voting
     /// @param _dao The DAO address creating the Whitelist Voting
     /// @param _whitelistVoters The array of the allowed voting addresses
     /// @param _voteConfig The voting settings

--- a/packages/contracts/contracts/factory/TokenFactory.sol
+++ b/packages/contracts/contracts/factory/TokenFactory.sol
@@ -25,6 +25,10 @@ contract TokenFactory {
 
     MerkleDistributor public distributorBase;
 
+    /// @notice Emitted when a new token is created
+    /// @param token ERC20 Upgradeable token address
+    /// @param minter The Merkle minter of the new token
+    /// @param distributor The Merkle distibutor of the new token
     event TokenCreated(IERC20Upgradeable token, MerkleMinter minter, MerkleDistributor distributor);
 
     struct TokenConfig {

--- a/packages/contracts/contracts/factory/TokenFactory.sol
+++ b/packages/contracts/contracts/factory/TokenFactory.sol
@@ -27,8 +27,8 @@ contract TokenFactory {
 
     /// @notice Emitted when a new token is created
     /// @param token ERC20 Upgradeable token address
-    /// @param minter The Merkle minter of the new token
-    /// @param distributor The Merkle distibutor of the new token
+    /// @param minter The `MerkleMinter` contract minting the new token
+    /// @param distributor The `MerkleDistibutor` contract distributing the new token
     event TokenCreated(IERC20Upgradeable token, MerkleMinter minter, MerkleDistributor distributor);
 
     struct TokenConfig {
@@ -47,8 +47,8 @@ contract TokenFactory {
     }
 
     /// TODO: Worth considering the decimals ?
-    /// @notice if addr is zero, creates new token + merkle minter, otherwise, creates a wrapped token only.
-    /// @notice if receiver addr is zero, mint token to DAO's address.
+    /// @notice If addr is zero, creates new token + merkle minter, otherwise, creates a wrapped token only.
+    /// @notice If receiver address is zero, mint token to DAO's address.
     /// @param _dao The dao address
     /// @param _tokenConfig The address of the token, name, and symbol. If no addr is passed will a new token get created.
     /// @param _mintConfig contains addresses and values(where to mint tokens and how much)
@@ -122,7 +122,7 @@ contract TokenFactory {
         return (ERC20VotesUpgradeable(token), MerkleMinter(merkleMinter));
     }
 
-    // @dev private helper method to set up the required base contracts on TokenFactory deployment.
+    // @dev Private helper method to set up the required base contracts on TokenFactory deployment.
     function setupBases() private {
         distributorBase = new MerkleDistributor();
         governanceERC20Base = address(new GovernanceERC20());

--- a/packages/contracts/contracts/registry/Registry.sol
+++ b/packages/contracts/contracts/registry/Registry.sol
@@ -12,7 +12,7 @@ contract Registry {
     /// @param name The DAO name requested for registration
     error RegistryNameAlreadyUsed(string name);
 
-    /// @notice Emitted if a new DAO is registered
+    /// @notice Emitted when a new DAO is registered
     /// @param dao The address of the DAO contract
     /// @param creator The address of the creator
     /// @param name The name of the DAO

--- a/packages/contracts/contracts/test/AdaptiveERC165Mock.sol
+++ b/packages/contracts/contracts/test/AdaptiveERC165Mock.sol
@@ -21,7 +21,7 @@ contract AdaptiveERC165Mock is AdaptiveERC165 {
 contract AdaptiveERC165MockHelper {
     address addr;
 
-    event ReceivedCallback(bytes32 b);
+    event CallbackReceived(bytes32 b);
 
     constructor(address _addr) {
         addr = _addr;
@@ -34,6 +34,6 @@ contract AdaptiveERC165MockHelper {
     function handleCallback(bytes4 selector) external {
         (, bytes memory value) = addr.call(abi.encodeWithSelector(selector));
         bytes32 decoded = abi.decode(value, (bytes32));
-        emit ReceivedCallback(decoded);
+        emit CallbackReceived(decoded);
     }
 }

--- a/packages/contracts/contracts/utils/Uint256Helpers.sol
+++ b/packages/contracts/contracts/utils/Uint256Helpers.sol
@@ -5,8 +5,13 @@ pragma solidity 0.8.10;
 library Uint256Helpers {
     uint256 private constant MAX_UINT64 = type(uint64).max;
 
+    /// @notice Thrown if the checked value is over the max value
+    /// @param maxValue The maximum value
+    /// @param value The compared value
     error OutOfBounds(uint256 maxValue, uint256 value);
 
+    /// @notice Method to safe cast a value to an unsigned 64 integer making sure is not out of the bounds
+    /// @param a The value to convert
     function toUint64(uint256 a) internal pure returns (uint64) {
         if (a > MAX_UINT64) revert OutOfBounds({maxValue: MAX_UINT64, value: a});
         return uint64(a);

--- a/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
+++ b/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
@@ -107,7 +107,7 @@ contract ERC20Voting is MajorityVoting {
             }
         }
 
-        emit StartVote(voteId, _msgSender(), _proposalMetadata);
+        emit VoteStarted(voteId, _msgSender(), _proposalMetadata);
 
         if (_choice != VoterState.None && canVote(voteId, _msgSender())) {
             _vote(voteId, _choice, _msgSender(), _executeIfDecided);
@@ -150,7 +150,7 @@ contract ERC20Voting is MajorityVoting {
 
         vote_.voters[_voter] = _choice;
 
-        emit CastVote(_voteId, _voter, uint8(_choice), voterStake);
+        emit VoteCast(_voteId, _voter, uint8(_choice), voterStake);
 
         if (_executesIfDecided && _canExecute(_voteId)) {
             _execute(_voteId);

--- a/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
+++ b/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
@@ -59,13 +59,7 @@ contract ERC20Voting is MajorityVoting {
         return "0.0.1+opengsn.recipient.ERC20Voting";
     }
 
-    /// @notice Create a new vote on this concrete implementation
-    /// @param _proposalMetadata The IPFS hash pointing to the proposal metadata
-    /// @param _actions the actions that will be executed after vote passes
-    /// @param _startDate state date of the vote. If 0, uses current timestamp
-    /// @param _endDate end date of the vote. If 0, uses _start + minDuration
-    /// @param _executeIfDecided Configuration to enable automatic execution on the last required vote
-    /// @param _choice Vote choice to cast on creation
+    /// @inheritdoc IMajorityVoting
     function newVote(
         bytes calldata _proposalMetadata,
         IDAO.Action[] calldata _actions,
@@ -117,10 +111,7 @@ contract ERC20Voting is MajorityVoting {
         }
     }
 
-    /// @dev Internal function to cast a vote. It assumes the queried vote exists.
-    /// @param _voteId voteId
-    /// @param _choice Whether voter abstains, supports or not supports to vote.
-    /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
+    /// @inheritdoc MajorityVoting
     function _vote(
         uint256 _voteId,
         VoterState _choice,
@@ -160,10 +151,7 @@ contract ERC20Voting is MajorityVoting {
         }
     }
 
-    /// @dev Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
-    /// @param _voteId The voteId
-    /// @param _voter the address of the voter to check
-    /// @return True if the given voter can participate a certain vote, false otherwise
+    /// @inheritdoc MajorityVoting
     function _canVote(uint256 _voteId, address _voter) internal view override returns (bool) {
         Vote storage vote_ = votes[_voteId];
         return _isVoteOpen(vote_) && votingToken.getPastVotes(_voter, vote_.snapshotBlock) > 0;

--- a/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
+++ b/packages/contracts/contracts/votings/ERC20/ERC20Voting.sol
@@ -15,6 +15,9 @@ contract ERC20Voting is MajorityVoting {
 
     ERC20VotesUpgradeable private votingToken;
 
+    /// @notice Thrown if the voting power is zero
+    error VotingPowerZero();
+
     /// @notice Initializes the component
     /// @dev This is required for the UUPS upgradability pattern
     /// @param _dao The IDAO interface of the associated DAO
@@ -74,7 +77,7 @@ contract ERC20Voting is MajorityVoting {
         uint64 snapshotBlock = getBlockNumber64() - 1;
 
         uint256 votingPower = votingToken.getPastTotalSupply(snapshotBlock);
-        if (votingPower == 0) revert VotePowerZero();
+        if (votingPower == 0) revert VotingPowerZero();
 
         voteId = votesLength++;
 

--- a/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
@@ -38,15 +38,15 @@ interface IMajorityVoting {
     error VoteExecutionForbidden(uint256 voteId);
     error VotePowerZero();
 
-    event StartVote(uint256 indexed voteId, address indexed creator, bytes metadata);
-    event CastVote(
+    event VoteStarted(uint256 indexed voteId, address indexed creator, bytes metadata);
+    event VoteCast(
         uint256 indexed voteId,
         address indexed voter,
         uint8 voterState,
         uint256 voterWeight
     );
-    event ExecuteVote(uint256 indexed voteId, bytes[] execResults);
-    event UpdateConfig(
+    event VoteExecuted(uint256 indexed voteId, bytes[] execResults);
+    event ConfigUpdated(
         uint64 participationRequiredPct,
         uint64 supportRequiredPct,
         uint64 minDuration

--- a/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
@@ -73,12 +73,12 @@ interface IMajorityVoting {
         uint64 _minDuration
     ) external;
 
-    /// @notice Create a new vote on this concrete implementation
+    /// @notice Create a new vote
     /// @param _proposalMetadata The IPFS hash pointing to the proposal metadata
     /// @param _actions The actions that will be executed after vote passes
-    /// @param _startDate The state date of the vote. If 0, uses current timestamp
+    /// @param _startDate The start date of the vote. If 0, uses current timestamp
     /// @param _endDate The end date of the vote. If 0, uses _start + minDuration
-    /// @param _executeIfDecided The configuration to enable automatic execution on the last required vote
+    /// @param _executeIfDecided Option to enable automatic execution on the last required vote
     /// @param _choice The vote choice to cast on creation
     /// @return voteId The ID of the vote
     function newVote(
@@ -90,7 +90,8 @@ interface IMajorityVoting {
         VoterState _choice
     ) external returns (uint256 voteId);
 
-    /// @notice Vote `[outcome = 1 = abstain], [outcome = 2 = supports], [outcome = 3 = not supports]
+    /// @notice Votes for a vote option and optionally executes the vote
+    /// @dev `[outcome = 1 = abstain], [outcome = 2 = supports], [outcome = 3 = not supports]
     /// @param _voteId The ID of the vote
     /// @param  _choice Whether voter abstains, supports or not supports to vote.
     /// @param _executesIfDecided Whether the vote should execute its action if it becomes decided

--- a/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
@@ -30,14 +30,6 @@ interface IMajorityVoting {
         IDAO.Action[] actions;
     }
 
-    error VoteSupportExceeded(uint64 limit, uint64 actual);
-    error VoteParticipationExceeded(uint64 limit, uint64 actual);
-    error VoteTimesForbidden(uint64 current, uint64 start, uint64 end, uint64 minDuration);
-    error VoteDurationZero();
-    error VoteCastForbidden(uint256 voteId, address sender);
-    error VoteExecutionForbidden(uint256 voteId);
-    error VotePowerZero();
-
     event VoteStarted(uint256 indexed voteId, address indexed creator, bytes metadata);
     event VoteCast(
         uint256 indexed voteId,

--- a/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
@@ -30,14 +30,33 @@ interface IMajorityVoting {
         IDAO.Action[] actions;
     }
 
+    /// @notice Emitted when a vote is started
+    /// @param voteId  The ID of the vote
+    /// @param creator  The creator of the vote
+    /// @param metadata The IPFS hash pointing to the proposal metadata
     event VoteStarted(uint256 indexed voteId, address indexed creator, bytes metadata);
+
+    /// @notice Emitted when a vote is casted by a voter
+    /// @param voteId The ID of the vote
+    /// @param voter The voter casting the vote
+    /// @param voterState The vote option chosen
+    /// @param voterWeight The weight of the casted vote
     event VoteCast(
         uint256 indexed voteId,
         address indexed voter,
         uint8 voterState,
         uint256 voterWeight
     );
+
+    /// @notice Emitted when a vote is executed
+    /// @param voteId The ID of the vote
+    /// @param execResults The bytes array resulting from the vote execution in the associated DAO
     event VoteExecuted(uint256 indexed voteId, bytes[] execResults);
+
+    /// @notice Emitted when the vote configuration is updated
+    /// @param participationRequiredPct The required participation in percent
+    /// @param supportRequiredPct The required support in percent
+    /// @param minDuration The minimal duration of a vote
     event ConfigUpdated(
         uint64 participationRequiredPct,
         uint64 supportRequiredPct,
@@ -45,9 +64,9 @@ interface IMajorityVoting {
     );
 
     /// @notice Change required support and minQuorum
-    /// @param _supportRequiredPct New required support
-    /// @param _participationRequiredPct New acceptance quorum
-    /// @param _minDuration each vote's minimum duration
+    /// @param _participationRequiredPct The required participation in percent
+    /// @param _supportRequiredPct The required support in percent
+    /// @param _minDuration The minimal duration of a vote
     function changeVoteConfig(
         uint64 _participationRequiredPct,
         uint64 _supportRequiredPct,
@@ -56,11 +75,11 @@ interface IMajorityVoting {
 
     /// @notice Create a new vote on this concrete implementation
     /// @param _proposalMetadata The IPFS hash pointing to the proposal metadata
-    /// @param _actions the actions that will be executed after vote passes
-    /// @param _startDate state date of the vote. If 0, uses current timestamp
-    /// @param _endDate end date of the vote. If 0, uses _start + minDuration
-    /// @param _executeIfDecided Configuration to enable automatic execution on the last required vote
-    /// @param _choice Vote choice to cast on creation
+    /// @param _actions The actions that will be executed after vote passes
+    /// @param _startDate The state date of the vote. If 0, uses current timestamp
+    /// @param _endDate The end date of the vote. If 0, uses _start + minDuration
+    /// @param _executeIfDecided The configuration to enable automatic execution on the last required vote
+    /// @param _choice The vote choice to cast on creation
     /// @return voteId The ID of the vote
     function newVote(
         bytes calldata _proposalMetadata,
@@ -71,8 +90,8 @@ interface IMajorityVoting {
         VoterState _choice
     ) external returns (uint256 voteId);
 
-    /// @notice Vote `[outcome = 1 = abstain], [outcome = 2 = supports], [outcome = 1 = not supports]
-    /// @param _voteId Id for vote
+    /// @notice Vote `[outcome = 1 = abstain], [outcome = 2 = supports], [outcome = 3 = not supports]
+    /// @param _voteId The ID of the vote
     /// @param  _choice Whether voter abstains, supports or not supports to vote.
     /// @param _executesIfDecided Whether the vote should execute its action if it becomes decided
     function vote(
@@ -91,29 +110,33 @@ interface IMajorityVoting {
     /// @param _voteId The ID of the vote to execute
     function execute(uint256 _voteId) external;
 
-    /// @notice Method to execute a vote if allowed to
+    /// @notice Checks if a vote is allowed to execute
     /// @param _voteId The ID of the vote to execute
     function canExecute(uint256 _voteId) external view returns (bool);
 
-    /// @notice Return the state of a voter for a given vote by its ID
+    /// @notice Returns the state of a voter for a given vote by its ID
     /// @param _voteId The ID of the vote
     /// @return VoterState of the requested voter for a certain vote
     function getVoterState(uint256 _voteId, address _voter) external view returns (VoterState);
 
-    /// @notice Return all information for a vote by its ID
-    /// @param _voteId Vote id
-    /// @return open Vote open status
-    /// @return executed Vote executed status
-    /// @return startDate start date
-    /// @return endDate end date
+    /// @param participationRequiredPct The required participation in percent
+    /// @param supportRequiredPct The required support in percent
+    /// @param minDuration The minimal duration of a vote
+
+    /// @notice Returns all information for a vote by its ID
+    /// @param _voteId The ID of the vote
+    /// @return open Wheter the vote is open or not
+    /// @return executed Wheter the vote is executed or not
+    /// @return startDate The start date of the vote
+    /// @return endDate The end date of the vote
     /// @return snapshotBlock The block number of the snapshot taken for this vote
-    /// @return supportRequired support required
-    /// @return participationRequired minimum participation required
-    /// @return votingPower power
-    /// @return yea yeas amount
-    /// @return nay nays amount
-    /// @return abstain abstain amount
-    /// @return actions Actions
+    /// @return supportRequired The support required
+    /// @return participationRequired The required participation
+    /// @return votingPower The voting power participating in the vote
+    /// @return yea The number of `yes` votes
+    /// @return nay The number of `no` votes
+    /// @return abstain The number of `abstain` votes
+    /// @return actions The actions to be executed in the associated DAO after the vote has passed
     function getVote(uint256 _voteId)
         external
         view

--- a/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/IMajorityVoting.sol
@@ -81,26 +81,26 @@ interface IMajorityVoting {
         bool _executesIfDecided
     ) external;
 
-    /// @dev Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
+    /// @notice Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
     /// @param _voteId the vote Id
     /// @param _voter the address of the voter to check
     /// @return bool true if user is allowed to vote
     function canVote(uint256 _voteId, address _voter) external view returns (bool);
 
-    /// @dev Method to execute a vote if allowed to
+    /// @notice Method to execute a vote if allowed to
     /// @param _voteId The ID of the vote to execute
     function execute(uint256 _voteId) external;
 
-    /// @dev Method to execute a vote if allowed to
+    /// @notice Method to execute a vote if allowed to
     /// @param _voteId The ID of the vote to execute
     function canExecute(uint256 _voteId) external view returns (bool);
 
-    /// @dev Return the state of a voter for a given vote by its ID
+    /// @notice Return the state of a voter for a given vote by its ID
     /// @param _voteId The ID of the vote
     /// @return VoterState of the requested voter for a certain vote
     function getVoterState(uint256 _voteId, address _voter) external view returns (VoterState);
 
-    /// @dev Return all information for a vote by its ID
+    /// @notice Return all information for a vote by its ID
     /// @param _voteId Vote id
     /// @return open Vote open status
     /// @return executed Vote executed status

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -23,6 +23,14 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     uint64 public minDuration;
     uint256 public votesLength;
 
+    error VoteSupportExceeded(uint64 limit, uint64 actual);
+    error VoteParticipationExceeded(uint64 limit, uint64 actual);
+    error VoteTimesForbidden(uint64 current, uint64 start, uint64 end, uint64 minDuration);
+    error VoteDurationZero();
+    error VoteCastForbidden(uint256 voteId, address sender);
+    error VoteExecutionForbidden(uint256 voteId);
+    error VotePowerZero();
+
     /// @notice Initializes the component
     /// @dev This is required for the UUPS upgradability pattern
     /// @param _dao The IDAO interface of the associated DAO

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -42,7 +42,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
 
         __MetaTxComponent_init(_dao, _gsnForwarder);
 
-        emit UpdateConfig(_participationRequiredPct, _supportRequiredPct, _minDuration);
+        emit ConfigUpdated(_participationRequiredPct, _supportRequiredPct, _minDuration);
     }
 
     /// @inheritdoc IMajorityVoting
@@ -53,7 +53,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     ) external auth(MODIFY_VOTE_CONFIG) {
         _validateAndSetSettings(_participationRequiredPct, _supportRequiredPct, _minDuration);
 
-        emit UpdateConfig(_participationRequiredPct, _supportRequiredPct, _minDuration);
+        emit ConfigUpdated(_participationRequiredPct, _supportRequiredPct, _minDuration);
     }
 
     /// @inheritdoc IMajorityVoting
@@ -151,7 +151,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
 
         votes[_voteId].executed = true;
 
-        emit ExecuteVote(_voteId, execResults);
+        emit VoteExecuted(_voteId, execResults);
     }
 
     /// @dev Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -50,7 +50,6 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
 
     /// @notice Thrown if the vote execution is forbidden
     error VoteExecutionForbidden(uint256 voteId);
-    error VotePowerZero();
 
     /// @notice Initializes the component
     /// @dev This is required for the UUPS upgradability pattern

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -164,7 +164,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     /// @notice Internal function to cast a vote. It assumes the queried vote exists.
     /// @param _voteId The ID of the vote
     /// @param _choice Whether voter abstains, supports or not supports to vote.
-    /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
+    /// @param _executesIfDecided if true, and it's the last vote required, immediately executes a vote.
     function _vote(
         uint256 _voteId,
         VoterState _choice,

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -23,11 +23,32 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     uint64 public minDuration;
     uint256 public votesLength;
 
+    /// @notice Thrown if the maximal possible support is exceeded
+    /// @param limit The maximal value
+    /// @param actual The actual value
     error VoteSupportExceeded(uint64 limit, uint64 actual);
+
+    /// @notice Thrown if the maximal possible participation is exceeded
+    /// @param limit The maximal value
+    /// @param actual The actual value
     error VoteParticipationExceeded(uint64 limit, uint64 actual);
+
+    /// @notice Thrown if the selected vote times are not allowed
+    /// @param current The maximal value
+    /// @param start The start date of the vote as a unix timestamp
+    /// @param end The end date of the vote as a unix timestamp
+    /// @param minDuration The minimal duration of the vote in seconds
     error VoteTimesForbidden(uint64 current, uint64 start, uint64 end, uint64 minDuration);
+
+    /// @notice Thrown if the selected vote duration is zero
     error VoteDurationZero();
+
+    /// @notice Thrown if a voter is not allowed to cast a vote
+    /// @param voteId The ID of the vote
+    /// @param sender The address of the voter
     error VoteCastForbidden(uint256 voteId, address sender);
+
+    /// @notice Thrown if the vote execution is forbidden
     error VoteExecutionForbidden(uint256 voteId);
     error VotePowerZero();
 
@@ -142,7 +163,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     }
 
     /// @notice Internal function to cast a vote. It assumes the queried vote exists.
-    /// @param _voteId voteId
+    /// @param _voteId The ID of the vote
     /// @param _choice Whether voter abstains, supports or not supports to vote.
     /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
     function _vote(
@@ -153,7 +174,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     ) internal virtual;
 
     /// @notice Internal function to execute a vote. It assumes the queried vote exists.
-    /// @param _voteId the vote Id
+    /// @param _voteId The ID of the vote
     function _execute(uint256 _voteId) internal virtual {
         bytes[] memory execResults = dao.execute(_voteId, votes[_voteId].actions);
 
@@ -163,13 +184,13 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
     }
 
     /// @notice Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
-    /// @param _voteId The voteId
+    /// @param _voteId The ID of the vote
     /// @param _voter the address of the voter to check
     /// @return True if the given voter can participate a certain vote, false otherwise
     function _canVote(uint256 _voteId, address _voter) internal view virtual returns (bool);
 
     /// @notice Internal function to check if a vote can be executed. It assumes the queried vote exists.
-    /// @param _voteId vote id
+    /// @param _voteId The ID of the vote
     /// @return True if the given vote can be executed, false otherwise
     function _canExecute(uint256 _voteId) internal view virtual returns (bool) {
         Vote storage vote_ = votes[_voteId];

--- a/packages/contracts/contracts/votings/majority/MajorityVoting.sol
+++ b/packages/contracts/contracts/votings/majority/MajorityVoting.sol
@@ -141,7 +141,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
         actions = vote_.actions;
     }
 
-    /// @dev Internal function to cast a vote. It assumes the queried vote exists.
+    /// @notice Internal function to cast a vote. It assumes the queried vote exists.
     /// @param _voteId voteId
     /// @param _choice Whether voter abstains, supports or not supports to vote.
     /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
@@ -152,7 +152,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
         bool _executesIfDecided
     ) internal virtual;
 
-    /// @dev Internal function to execute a vote. It assumes the queried vote exists.
+    /// @notice Internal function to execute a vote. It assumes the queried vote exists.
     /// @param _voteId the vote Id
     function _execute(uint256 _voteId) internal virtual {
         bytes[] memory execResults = dao.execute(_voteId, votes[_voteId].actions);
@@ -162,13 +162,13 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
         emit VoteExecuted(_voteId, execResults);
     }
 
-    /// @dev Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
+    /// @notice Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
     /// @param _voteId The voteId
     /// @param _voter the address of the voter to check
     /// @return True if the given voter can participate a certain vote, false otherwise
     function _canVote(uint256 _voteId, address _voter) internal view virtual returns (bool);
 
-    /// @dev Internal function to check if a vote can be executed. It assumes the queried vote exists.
+    /// @notice Internal function to check if a vote can be executed. It assumes the queried vote exists.
     /// @param _voteId vote id
     /// @return True if the given vote can be executed, false otherwise
     function _canExecute(uint256 _voteId) internal view virtual returns (bool) {
@@ -209,7 +209,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
         return true;
     }
 
-    /// @dev Internal function to check if a vote is still open
+    /// @notice Internal function to check if a vote is still open
     /// @param vote_ the vote struct
     /// @return True if the given vote is open, false otherwise
     function _isVoteOpen(Vote storage vote_) internal view virtual returns (bool) {
@@ -219,7 +219,7 @@ abstract contract MajorityVoting is IMajorityVoting, MetaTxComponent, TimeHelper
             !vote_.executed;
     }
 
-    /// @dev Calculates whether `_value` is more than a percentage `_pct` of `_total`
+    /// @notice Calculates whether `_value` is more than a percentage `_pct` of `_total`
     /// @param _value the current value
     /// @param _total the total value
     /// @param _pct the required support percentage

--- a/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
+++ b/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
@@ -26,8 +26,9 @@ contract WhitelistVoting is MajorityVoting {
 
     error VoteCreationForbidden(address sender);
 
-    event AddUsers(address[] users);
-    event RemoveUsers(address[] users);
+    event UsersAdded(address[] users);
+
+    event UsersRemoved(address[] users);
 
     /// @notice Initializes the component
     /// @dev This is required for the UUPS upgradability pattern
@@ -75,7 +76,7 @@ contract WhitelistVoting is MajorityVoting {
     function _addWhitelistedUsers(address[] calldata _users) internal {
         _whitelistUsers(_users, true);
 
-        emit AddUsers(_users);
+        emit UsersAdded(_users);
     }
 
     /// @notice remove new users to the whitelist.
@@ -83,7 +84,7 @@ contract WhitelistVoting is MajorityVoting {
     function removeWhitelistedUsers(address[] calldata _users) external auth(MODIFY_WHITELIST) {
         _whitelistUsers(_users, false);
 
-        emit RemoveUsers(_users);
+        emit UsersRemoved(_users);
     }
 
     /// @notice Create a new vote on this concrete implementation
@@ -138,7 +139,7 @@ contract WhitelistVoting is MajorityVoting {
             }
         }
 
-        emit StartVote(voteId, _msgSender(), _proposalMetadata);
+        emit VoteStarted(voteId, _msgSender(), _proposalMetadata);
 
         if (_choice != VoterState.None && canVote(voteId, _msgSender())) {
             _vote(voteId, VoterState.Yea, _msgSender(), _executeIfDecided);
@@ -179,7 +180,7 @@ contract WhitelistVoting is MajorityVoting {
 
         vote_.voters[_voter] = _choice;
 
-        emit CastVote(_voteId, _voter, uint8(_choice), 1);
+        emit VoteCast(_voteId, _voter, uint8(_choice), 1);
 
         if (_executesIfDecided && _canExecute(_voteId)) {
             _execute(_voteId);

--- a/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
+++ b/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
@@ -71,7 +71,7 @@ contract WhitelistVoting is MajorityVoting {
         _addWhitelistedUsers(_users);
     }
 
-    /// @dev Internal function to add new users to the whitelist.
+    /// @notice Internal function to add new users to the whitelist.
     /// @param _users addresses of users to add
     function _addWhitelistedUsers(address[] calldata _users) internal {
         _whitelistUsers(_users, true);
@@ -146,7 +146,7 @@ contract WhitelistVoting is MajorityVoting {
         }
     }
 
-    /// @dev Internal function to cast a vote. It assumes the queried vote exists.
+    /// @notice Internal function to cast a vote. It assumes the queried vote exists.
     /// @param _voteId voteId
     /// @param _choice Whether voter abstains, supports or not supports to vote.
     /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
@@ -187,44 +187,36 @@ contract WhitelistVoting is MajorityVoting {
         }
     }
 
-    /**
-     *  @dev Tells whether user is whitelisted at specific block or past it.
-     *  @param account user address
-     *  @param blockNumber block number for which it checks if user is whitelisted
-     */
+    /// @notice Tells whether user is whitelisted at specific block or past it.
+    /// @param account user address
+    /// @param blockNumber block number for which it checks if user is whitelisted
     function isUserWhitelisted(address account, uint256 blockNumber) public view returns (bool) {
         if (blockNumber == 0) blockNumber = getBlockNumber64() - 1;
 
         return _checkpoints[account].getAtBlock(blockNumber) == 1;
     }
 
-    /**
-     *  @dev returns total count of users that are whitelisted at specific block
-     *  @param blockNumber specific block to get count from
-     *  @return count of users that are whitelisted blockNumber or prior to it.
-     */
+    /// @notice returns total count of users that are whitelisted at specific block
+    /// @param blockNumber specific block to get count from
+    /// @return count of users that are whitelisted blockNumber or prior to it.
     function whitelistedUserCount(uint256 blockNumber) public view returns (uint256) {
         if (blockNumber == 0) blockNumber = getBlockNumber64() - 1;
 
         return _totalCheckpoints.getAtBlock(blockNumber);
     }
 
-    /**
-     * @dev Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
-     * @param _voteId The voteId
-     * @param _voter the address of the voter to check
-     * @return True if the given voter can participate a certain vote, false otherwise
-     */
+    /// @notice Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
+    /// @param _voteId The voteId
+    /// @param _voter the address of the voter to check
+    /// @return True if the given voter can participate a certain vote, false otherwise
     function _canVote(uint256 _voteId, address _voter) internal view override returns (bool) {
         Vote storage vote_ = votes[_voteId];
         return _isVoteOpen(vote_) && isUserWhitelisted(_voter, vote_.snapshotBlock);
     }
 
-    /**
-     *  @dev Adds or removes users from whitelist
-     *  @param _users user addresses
-     *  @param _enabled whether to add or remove from whitelist
-     */
+    /// @notice Adds or removes users from whitelist
+    /// @param _users user addresses
+    /// @param _enabled whether to add or remove from whitelist
     function _whitelistUsers(address[] calldata _users, bool _enabled) internal {
         _totalCheckpoints.push(_enabled ? _add : _sub, _users.length);
 

--- a/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
+++ b/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
@@ -65,7 +65,7 @@ contract WhitelistVoting is MajorityVoting {
         return "0.0.1+opengsn.recipient.WhitelistVoting";
     }
 
-    /// @notice add new users to the whitelist.
+    /// @notice Adds new users to the whitelist
     /// @param _users addresses of users to add
     function addWhitelistedUsers(address[] calldata _users) external auth(MODIFY_WHITELIST) {
         _addWhitelistedUsers(_users);
@@ -79,7 +79,7 @@ contract WhitelistVoting is MajorityVoting {
         emit UsersAdded(_users);
     }
 
-    /// @notice remove new users to the whitelist.
+    /// @notice Removes users to the whitelist.
     /// @param _users addresses of users to remove
     function removeWhitelistedUsers(address[] calldata _users) external auth(MODIFY_WHITELIST) {
         _whitelistUsers(_users, false);
@@ -87,13 +87,7 @@ contract WhitelistVoting is MajorityVoting {
         emit UsersRemoved(_users);
     }
 
-    /// @notice Create a new vote on this concrete implementation
-    /// @param _proposalMetadata The IPFS hash pointing to the proposal metadata
-    /// @param _actions the actions that will be executed after vote passes
-    /// @param _startDate state date of the vote. If 0, uses current timestamp
-    /// @param _endDate end date of the vote. If 0, uses _start + minDuration
-    /// @param _executeIfDecided Configuration to enable automatic execution on the last required vote
-    /// @param _choice Vote choice to cast on creationr
+    /// @inheritdoc IMajorityVoting
     function newVote(
         bytes calldata _proposalMetadata,
         IDAO.Action[] calldata _actions,
@@ -146,10 +140,7 @@ contract WhitelistVoting is MajorityVoting {
         }
     }
 
-    /// @notice Internal function to cast a vote. It assumes the queried vote exists.
-    /// @param _voteId voteId
-    /// @param _choice Whether voter abstains, supports or not supports to vote.
-    /// @param _executesIfDecided if true, and it's the last vote required, immediatelly executes a vote.
+    /// @inheritdoc MajorityVoting
     function _vote(
         uint256 _voteId,
         VoterState _choice,
@@ -205,10 +196,7 @@ contract WhitelistVoting is MajorityVoting {
         return _totalCheckpoints.getAtBlock(blockNumber);
     }
 
-    /// @notice Internal function to check if a voter can participate on a vote. It assumes the queried vote exists.
-    /// @param _voteId The voteId
-    /// @param _voter the address of the voter to check
-    /// @return True if the given voter can participate a certain vote, false otherwise
+    /// @inheritdoc MajorityVoting
     function _canVote(uint256 _voteId, address _voter) internal view override returns (bool) {
         Vote storage vote_ = votes[_voteId];
         return _isVoteOpen(vote_) && isUserWhitelisted(_voter, vote_.snapshotBlock);

--- a/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
+++ b/packages/contracts/contracts/votings/whitelist/WhitelistVoting.sol
@@ -66,21 +66,21 @@ contract WhitelistVoting is MajorityVoting {
     }
 
     /// @notice Adds new users to the whitelist
-    /// @param _users addresses of users to add
+    /// @param _users The addresses of the users to be added
     function addWhitelistedUsers(address[] calldata _users) external auth(MODIFY_WHITELIST) {
         _addWhitelistedUsers(_users);
     }
 
-    /// @notice Internal function to add new users to the whitelist.
-    /// @param _users addresses of users to add
+    /// @notice Internal function to add new users to the whitelist
+    /// @param _users The addresses of users to be added
     function _addWhitelistedUsers(address[] calldata _users) internal {
         _whitelistUsers(_users, true);
 
         emit UsersAdded(_users);
     }
 
-    /// @notice Removes users to the whitelist.
-    /// @param _users addresses of users to remove
+    /// @notice Removes users from the whitelist
+    /// @param _users The addresses of the users to be removed
     function removeWhitelistedUsers(address[] calldata _users) external auth(MODIFY_WHITELIST) {
         _whitelistUsers(_users, false);
 
@@ -178,18 +178,18 @@ contract WhitelistVoting is MajorityVoting {
         }
     }
 
-    /// @notice Tells whether user is whitelisted at specific block or past it.
-    /// @param account user address
-    /// @param blockNumber block number for which it checks if user is whitelisted
+    /// @notice Checks if a user is whitelisted at given block number
+    /// @param account The user address that is checked
+    /// @param blockNumber The block number
     function isUserWhitelisted(address account, uint256 blockNumber) public view returns (bool) {
         if (blockNumber == 0) blockNumber = getBlockNumber64() - 1;
 
         return _checkpoints[account].getAtBlock(blockNumber) == 1;
     }
 
-    /// @notice returns total count of users that are whitelisted at specific block
-    /// @param blockNumber specific block to get count from
-    /// @return count of users that are whitelisted blockNumber or prior to it.
+    /// @notice Returns total count of users that are whitelisted at given block number
+    /// @param blockNumber The specific block to get the count from
+    /// @return The user count that were whitelisted at the specified block number
     function whitelistedUserCount(uint256 blockNumber) public view returns (uint256) {
         if (blockNumber == 0) blockNumber = getBlockNumber64() - 1;
 

--- a/packages/contracts/test/adaptive-erc165.ts
+++ b/packages/contracts/test/adaptive-erc165.ts
@@ -11,10 +11,17 @@ import {
 import {customError} from './test-utils/custom-error-helper';
 
 const EVENTS = {
+<<<<<<< Updated upstream
   REGISTERED_CALLBACK: 'RegisteredCallback',
   REGISTERED_STANDARD: 'RegisteredStandard',
   RECEIVED_CALLBACK: 'ReceivedCallback',
 };
+=======
+  REGISTERED_CALLBACK: 'CallbackRegistered',
+  REGISTERED_STANDARD: 'StandardRegistered',
+  RECEIVED_CALLBACK: 'CallbackReceived',
+}
+>>>>>>> Stashed changes
 
 const beefInterfaceId = '0xbeefbeef';
 const callbackSig = hexDataSlice(id('callbackFunc()'), 0, 4); // 0x1eb2075a

--- a/packages/contracts/test/adaptive-erc165.ts
+++ b/packages/contracts/test/adaptive-erc165.ts
@@ -11,17 +11,10 @@ import {
 import {customError} from './test-utils/custom-error-helper';
 
 const EVENTS = {
-<<<<<<< Updated upstream
-  REGISTERED_CALLBACK: 'RegisteredCallback',
-  REGISTERED_STANDARD: 'RegisteredStandard',
-  RECEIVED_CALLBACK: 'ReceivedCallback',
-};
-=======
   REGISTERED_CALLBACK: 'CallbackRegistered',
   REGISTERED_STANDARD: 'StandardRegistered',
   RECEIVED_CALLBACK: 'CallbackReceived',
 }
->>>>>>> Stashed changes
 
 const beefInterfaceId = '0xbeefbeef';
 const callbackSig = hexDataSlice(id('callbackFunc()'), 0, 4); // 0x1eb2075a

--- a/packages/contracts/test/core/dao.ts
+++ b/packages/contracts/test/core/dao.ts
@@ -17,7 +17,7 @@ const dummyMetadata2 = '0x0002';
 const EVENTS = {
   MetadataSet: 'MetadataSet',
   TrustedForwarderSet: 'TrustedForwarderSet',
-  UpdateConfig: 'UpdateConfig',
+  ConfigUpdated: 'ConfigUpdated',
   DAOCreated: 'DAOCreated',
   Granted: 'Granted',
   Revoked: 'Revoked',

--- a/packages/contracts/test/dao-factory.ts
+++ b/packages/contracts/test/dao-factory.ts
@@ -7,7 +7,7 @@ import {customError} from './test-utils/custom-error-helper';
 const EVENTS = {
   NewDAORegistered: 'NewDAORegistered',
   MetadataSet: 'MetadataSet',
-  UpdateConfig: 'UpdateConfig',
+  ConfigUpdated: 'ConfigUpdated',
   DAOCreated: 'DAOCreated',
   Granted: 'Granted',
   Revoked: 'Revoked',
@@ -175,7 +175,7 @@ describe('DAOFactory: ', function () {
     tx = tx.to
       .emit(dao, EVENTS.MetadataSet)
       .withArgs(daoDummyMetadata)
-      .to.emit(voting, EVENTS.UpdateConfig)
+      .to.emit(voting, EVENTS.ConfigUpdated)
       .withArgs(
         dummyVoteSettings.participationRequiredPct,
         dummyVoteSettings.supportRequiredPct,
@@ -258,7 +258,7 @@ describe('DAOFactory: ', function () {
     expect(await voting.vote(0, VoterState.Yea, true))
       .to.emit(dao, EVENTS.Executed)
       .withArgs(voting.address, 0, [], [])
-      .to.emit(voting, EVENTS.UpdateConfig)
+      .to.emit(voting, EVENTS.ConfigUpdated)
       .withArgs(3, 4, 5);
 
     expect(await actionExecuteContract.test()).to.equal(true);
@@ -303,7 +303,7 @@ describe('DAOFactory: ', function () {
     tx = tx.to
       .emit(dao, EVENTS.MetadataSet)
       .withArgs(daoDummyMetadata)
-      .to.emit(voting, EVENTS.UpdateConfig)
+      .to.emit(voting, EVENTS.ConfigUpdated)
       .withArgs(
         dummyVoteSettings.participationRequiredPct,
         dummyVoteSettings.supportRequiredPct,
@@ -394,7 +394,7 @@ describe('DAOFactory: ', function () {
     expect(await voting.vote(0, VoterState.Yea, true))
       .to.emit(dao, EVENTS.Executed)
       .withArgs(voting.address, 0, [], [])
-      .to.emit(voting, EVENTS.UpdateConfig)
+      .to.emit(voting, EVENTS.ConfigUpdated)
       .withArgs(3, 4, 5);
 
     expect(await actionExecuteContract.test()).to.equal(true);

--- a/packages/contracts/test/test-utils/voting.ts
+++ b/packages/contracts/test/test-utils/voting.ts
@@ -11,9 +11,9 @@ export const toBn = ethers.BigNumber.from;
 const bigExp = (x: number, y: number) => toBn(x).mul(toBn(10).pow(toBn(y)));
 export const pct16 = (x: number) => bigExp(x, 16);
 
-export const EVENTS = {
-  UPDATE_CONFIG: 'UpdateConfig',
-  START_VOTE: 'StartVote',
-  CAST_VOTE: 'CastVote',
-  EXECUTED: 'Executed',
+export const VOTING_EVENTS = {
+  CONFIG_UPDATED: 'ConfigUpdated',
+  VOTE_STARTED: 'VoteStarted',
+  VOTE_CAST: 'VoteCast',
+  VOTE_EXECUTED: 'VoteExecuted',
 };

--- a/packages/contracts/test/voting/erc20-voting.ts
+++ b/packages/contracts/test/voting/erc20-voting.ts
@@ -2,7 +2,7 @@ import chai, {expect} from 'chai';
 import {ethers, waffle} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import chaiUtils from '../test-utils';
-import {VoterState, EVENTS, pct16, toBn} from '../test-utils/voting';
+import {VoterState, VOTING_EVENTS, pct16, toBn} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 chai.use(chaiUtils);
@@ -11,6 +11,10 @@ import {ERC20Voting, DAOMock} from '../../typechain';
 import ERC20Governance from '../../artifacts/contracts/tokens/GovernanceERC20.sol/GovernanceERC20.json';
 
 const {deployMockContract} = waffle;
+
+const DAO_EVENTS = {
+  EXECUTED: 'Executed',
+};
 
 describe('ERC20Voting', function () {
   let signers: SignerWithAddress[];
@@ -113,7 +117,7 @@ describe('ERC20Voting', function () {
       expect(
         await voting.newVote('0x00', dummyActions, 0, 0, false, VoterState.None)
       )
-        .to.emit(voting, EVENTS.START_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_STARTED)
         .withArgs(0, ownerAddress, '0x00');
 
       const block = await ethers.provider.getBlock('latest');
@@ -144,9 +148,9 @@ describe('ERC20Voting', function () {
       expect(
         await voting.newVote('0x00', dummyActions, 0, 0, false, VoterState.Yea)
       )
-        .to.emit(voting, EVENTS.START_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_STARTED)
         .withArgs(0, ownerAddress, '0x00')
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Yea, 1);
 
       const block = await ethers.provider.getBlock('latest');
@@ -191,21 +195,21 @@ describe('ERC20Voting', function () {
       await erc20VoteMock.mock.getPastVotes.returns(1);
 
       expect(await voting.vote(0, VoterState.Yea, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Yea, 1);
 
       let vote = await voting.getVote(0);
       expect(vote.yea).to.equal(1);
 
       expect(await voting.vote(0, VoterState.Nay, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Nay, 1);
 
       vote = await voting.getVote(0);
       expect(vote.nay).to.equal(1);
 
       expect(await voting.vote(0, VoterState.Abstain, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Abstain, 1);
 
       vote = await voting.getVote(0);
@@ -300,7 +304,7 @@ describe('ERC20Voting', function () {
 
       // supports and should execute right away.
       expect(await voting.vote(0, VoterState.Yea, true))
-        .to.emit(daoMock, EVENTS.EXECUTED)
+        .to.emit(daoMock, DAO_EVENTS.EXECUTED)
         .withArgs(
           voting.address,
           0,
@@ -312,7 +316,9 @@ describe('ERC20Voting', function () {
             ],
           ],
           []
-        );
+        )
+        .to.emit(voting, VOTING_EVENTS.VOTE_EXECUTED)
+        .withArgs(0, []);
 
       const vote = await voting.getVote(0);
 

--- a/packages/contracts/test/voting/erc20-voting.ts
+++ b/packages/contracts/test/voting/erc20-voting.ts
@@ -88,7 +88,7 @@ describe('ERC20Voting', function () {
       await erc20VoteMock.mock.getPastTotalSupply.returns(0);
       await expect(
         voting.newVote('0x00', [], 0, 0, false, VoterState.None)
-      ).to.be.revertedWith(customError('VotePowerZero'));
+      ).to.be.revertedWith(customError('VotingPowerZero'));
     });
 
     it('reverts if vote duration is less than minDuration', async () => {

--- a/packages/contracts/test/voting/majority-voting.ts
+++ b/packages/contracts/test/voting/majority-voting.ts
@@ -2,7 +2,7 @@ import chai, {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import chaiUtils from '../test-utils';
-import {EVENTS, pct16} from '../test-utils/voting';
+import {VOTING_EVENTS, pct16} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 chai.use(chaiUtils);
@@ -92,7 +92,7 @@ describe('MajorityVotingMock', function () {
 
     it('should change config successfully', async () => {
       expect(await votingBase.changeVoteConfig(2, 4, 8))
-        .to.emit(votingBase, EVENTS.UPDATE_CONFIG)
+        .to.emit(votingBase, VOTING_EVENTS.CONFIG_UPDATED)
         .withArgs(2, 4, 8);
     });
   });

--- a/packages/contracts/test/voting/whitelist-voting.ts
+++ b/packages/contracts/test/voting/whitelist-voting.ts
@@ -2,12 +2,16 @@ import chai, {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import chaiUtils from '../test-utils';
-import {VoterState, EVENTS, pct16, toBn} from '../test-utils/voting';
+import {VoterState, VOTING_EVENTS, pct16, toBn} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 chai.use(chaiUtils);
 
 import {WhitelistVoting, DAOMock} from '../../typechain';
+
+const DAO_EVENTS = {
+  EXECUTED: 'Executed',
+};
 
 describe('WhitelistVoting', function () {
   let signers: SignerWithAddress[];
@@ -150,7 +154,7 @@ describe('WhitelistVoting', function () {
       expect(
         await voting.newVote('0x00', dummyActions, 0, 0, false, VoterState.None)
       )
-        .to.emit(voting, EVENTS.START_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_STARTED)
         .withArgs(0, ownerAddress, '0x00');
 
       const block = await ethers.provider.getBlock('latest');
@@ -178,9 +182,9 @@ describe('WhitelistVoting', function () {
       expect(
         await voting.newVote('0x00', dummyActions, 0, 0, false, VoterState.Yea)
       )
-        .to.emit(voting, EVENTS.START_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_STARTED)
         .withArgs(0, ownerAddress, '0x00')
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Yea, 1);
 
       const block = await ethers.provider.getBlock('latest');
@@ -224,21 +228,21 @@ describe('WhitelistVoting', function () {
     // VoterState.Yea
     it('increases the yea or nay count and emit correct events', async () => {
       expect(await voting.vote(0, VoterState.Yea, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Yea, 1);
 
       let vote = await voting.getVote(0);
       expect(vote.yea).to.equal(1);
 
       expect(await voting.vote(0, VoterState.Nay, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Nay, 1);
 
       vote = await voting.getVote(0);
       expect(vote.nay).to.equal(1);
 
       expect(await voting.vote(0, VoterState.Abstain, false))
-        .to.emit(voting, EVENTS.CAST_VOTE)
+        .to.emit(voting, VOTING_EVENTS.VOTE_CAST)
         .withArgs(0, ownerAddress, VoterState.Abstain, 1);
 
       vote = await voting.getVote(0);
@@ -309,7 +313,7 @@ describe('WhitelistVoting', function () {
 
       // 3th supports(which is enough) and should execute right away.
       expect(await voting.connect(signers[3]).vote(0, VoterState.Yea, true))
-        .to.emit(daoMock, EVENTS.EXECUTED)
+        .to.emit(daoMock, DAO_EVENTS.EXECUTED)
         .withArgs(
           voting.address,
           0,
@@ -321,7 +325,9 @@ describe('WhitelistVoting', function () {
             ],
           ],
           []
-        );
+        )
+        .to.emit(voting, VOTING_EVENTS.VOTE_EXECUTED)
+        .withArgs(0, []);
 
       const vote = await voting.getVote(0);
 

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Upcoming]
+
+### Changed
+- Refactored event names and NatSpec comments
+  
 ## v0.2.0-alpha
 
 ### Added

--- a/packages/subgraph/manifest/subgraph.placeholder.yaml
+++ b/packages/subgraph/manifest/subgraph.placeholder.yaml
@@ -85,14 +85,14 @@ templates:
         - name: ERC20Voting
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/votings/ERC20/ERC20Voting.sol/ERC20Voting.json
       eventHandlers:
-        - event: CastVote(indexed uint256,indexed address,uint8,uint256)
-          handler: handleCastVote
-        - event: ExecuteVote(indexed uint256,bytes[])
-          handler: handleExecuteVote
-        - event: StartVote(indexed uint256,indexed address,bytes)
-          handler: handleStartVote
-        - event: UpdateConfig(uint64,uint64,uint64)
-          handler: handleUpdateConfig
+        - event: VoteCast(indexed uint256,indexed address,uint8,uint256)
+          handler: handleVoteCast
+        - event: VoteExecuted(indexed uint256,bytes[])
+          handler: handleVoteExecuted
+        - event: VoteStarted(indexed uint256,indexed address,bytes)
+          handler: handleVoteStarted
+        - event: ConfigUpdated(uint64,uint64,uint64)
+          handler: handleConfigUpdated
         - event: TrustedForwarderSet(address)
           handler: handleTrustedForwarderSet
   # WhitelistVoting (package)
@@ -112,17 +112,17 @@ templates:
         - name: WhitelistVoting
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/votings/whitelist/WhitelistVoting.sol/WhitelistVoting.json
       eventHandlers:
-        - event: CastVote(indexed uint256,indexed address,uint8,uint256)
-          handler: handleCastVote
-        - event: ExecuteVote(indexed uint256,bytes[])
-          handler: handleExecuteVote
-        - event: StartVote(indexed uint256,indexed address,bytes)
-          handler: handleStartVote
-        - event: UpdateConfig(uint64,uint64,uint64)
-          handler: handleUpdateConfig
-        - event: AddUsers(address[])
-          handler: handleAddUsers
-        - event: RemoveUsers(address[])
-          handler: handleRemoveUsers
+        - event: VoteCast(indexed uint256,indexed address,uint8,uint256)
+          handler: handleVoteCast
+        - event: VoteExecuted(indexed uint256,bytes[])
+          handler: handleVoteExecuted
+        - event: VoteStarted(indexed uint256,indexed address,bytes)
+          handler: handleVoteStarted
+        - event: ConfigUpdated(uint64,uint64,uint64)
+          handler: handleConfigUpdated
+        - event: UsersAdded(address[])
+          handler: handleUsersAdded
+        - event: UsersRemoved(address[])
+          handler: handleUsersRemoved
         - event: TrustedForwarderSet(address)
           handler: handleTrustedForwarderSet

--- a/packages/subgraph/src/dao/dao.ts
+++ b/packages/subgraph/src/dao/dao.ts
@@ -20,7 +20,7 @@ import {ADDRESS_ZERO} from '../utils/constants';
 import {addPackage, decodeWithdrawParams, removePackage} from './utils';
 import {handleERC20Token, updateBalance} from '../utils/tokens';
 
-export function handleSetMetadata(event: MetadataSet): void {
+export function handleMetadataSet(event: MetadataSet): void {
   let daoId = event.address.toHexString();
   let metadata = event.params.metadata.toString();
   _handleMetadataSet(daoId, metadata);

--- a/packages/subgraph/src/dao/dao.ts
+++ b/packages/subgraph/src/dao/dao.ts
@@ -20,7 +20,7 @@ import {ADDRESS_ZERO} from '../utils/constants';
 import {addPackage, decodeWithdrawParams, removePackage} from './utils';
 import {handleERC20Token, updateBalance} from '../utils/tokens';
 
-export function handleMetadataSet(event: MetadataSet): void {
+export function handleSetMetadata(event: MetadataSet): void {
   let daoId = event.address.toHexString();
   let metadata = event.params.metadata.toString();
   _handleMetadataSet(daoId, metadata);

--- a/packages/subgraph/src/packages/ERC20Voting/erc20Voting.ts
+++ b/packages/subgraph/src/packages/ERC20Voting/erc20Voting.ts
@@ -1,8 +1,8 @@
 import {
-  CastVote,
-  StartVote,
-  ExecuteVote,
-  UpdateConfig,
+  VoteCast,
+  VoteStarted,
+  VoteExecuted,
+  ConfigUpdated,
   ERC20Voting,
   TrustedForwarderSet
 } from '../../../generated/templates/ERC20Voting/ERC20Voting';
@@ -16,16 +16,16 @@ import {
 import {dataSource} from '@graphprotocol/graph-ts';
 import {VOTER_STATE} from '../../utils/constants';
 
-export function handleStartVote(event: StartVote): void {
+export function handleVoteStarted(event: VoteStarted): void {
   let context = dataSource.context();
   let daoId = context.getString('daoAddress');
   let metadata = event.params.metadata.toString();
-  _handleStartVote(event, daoId, metadata);
+  _handleVoteStarted(event, daoId, metadata);
 }
 
 // work around: to bypass context and ipfs for testing, as they are not yet supported by matchstick
-export function _handleStartVote(
-  event: StartVote,
+export function _handleVoteStarted(
+  event: VoteStarted,
   daoId: string,
   metadata: string
 ): void {
@@ -88,7 +88,7 @@ export function _handleStartVote(
   }
 }
 
-export function handleCastVote(event: CastVote): void {
+export function handleVoteCast(event: VoteCast): void {
   let proposalId =
     event.address.toHexString() + '_' + event.params.voteId.toHexString();
   let voterProposalId = event.params.voter.toHexString() + '_' + proposalId;
@@ -124,7 +124,7 @@ export function handleCastVote(event: CastVote): void {
   }
 }
 
-export function handleExecuteVote(event: ExecuteVote): void {
+export function handleVoteExecuted(event: VoteExecuted): void {
   let proposalId =
     event.address.toHexString() + '_' + event.params.voteId.toHexString();
   let proposalEntity = ERC20VotingProposal.load(proposalId);
@@ -155,7 +155,7 @@ export function handleExecuteVote(event: ExecuteVote): void {
   }
 }
 
-export function handleUpdateConfig(event: UpdateConfig): void {
+export function handleConfigUpdated(event: ConfigUpdated): void {
   let packageEntity = ERC20VotingPackage.load(event.address.toHexString());
   if (packageEntity) {
     packageEntity.supportRequiredPct = event.params.supportRequiredPct;

--- a/packages/subgraph/src/packages/whitelist/whitelistVoting.ts
+++ b/packages/subgraph/src/packages/whitelist/whitelistVoting.ts
@@ -3,8 +3,8 @@ import {
   VoteStarted,
   VoteExecuted,
   ConfigUpdated,
-  AddUsers,
-  RemoveUsers,
+  UsersAdded,
+  UsersRemoved,
   WhitelistVoting,
   TrustedForwarderSet
 } from '../../../generated/templates/WhitelistVoting/WhitelistVoting';
@@ -161,7 +161,7 @@ export function handleConfigUpdated(event: ConfigUpdated): void {
   }
 }
 
-export function handleAddUsers(event: AddUsers): void {
+export function handleUsersAdded(event: UsersAdded): void {
   let users = event.params.users;
   for (let index = 0; index < users.length; index++) {
     const user = users[index];
@@ -174,7 +174,7 @@ export function handleAddUsers(event: AddUsers): void {
   }
 }
 
-export function handleRemoveUsers(event: RemoveUsers): void {
+export function handleUsersRemoved(event: UsersRemoved): void {
   let users = event.params.users;
   for (let index = 0; index < users.length; index++) {
     const user = users[index];

--- a/packages/subgraph/src/packages/whitelist/whitelistVoting.ts
+++ b/packages/subgraph/src/packages/whitelist/whitelistVoting.ts
@@ -1,8 +1,8 @@
 import {
-  CastVote,
-  StartVote,
-  ExecuteVote,
-  UpdateConfig,
+  VoteCast,
+  VoteStarted,
+  VoteExecuted,
+  ConfigUpdated,
   AddUsers,
   RemoveUsers,
   WhitelistVoting,
@@ -18,16 +18,16 @@ import {
 import {dataSource, store} from '@graphprotocol/graph-ts';
 import {VOTER_STATE} from '../../utils/constants';
 
-export function handleStartVote(event: StartVote): void {
+export function handleVoteStarted(event: VoteStarted): void {
   let context = dataSource.context();
   let daoId = context.getString('daoAddress');
   let metdata = event.params.metadata.toString();
-  _handleStartVote(event, daoId, metdata);
+  _handleVoteStarted(event, daoId, metdata);
 }
 
 // work around: to bypass context and ipfs for testing, as they are not yet supported by matchstick
-export function _handleStartVote(
-  event: StartVote,
+export function _handleVoteStarted(
+  event: VoteStarted,
   daoId: string,
   metadata: string
 ): void {
@@ -90,7 +90,7 @@ export function _handleStartVote(
   }
 }
 
-export function handleCastVote(event: CastVote): void {
+export function handleVoteCast(event: VoteCast): void {
   let proposalId =
     event.address.toHexString() + '_' + event.params.voteId.toHexString();
   let voterProposalId = event.params.voter.toHexString() + '_' + proposalId;
@@ -119,7 +119,7 @@ export function handleCastVote(event: CastVote): void {
   }
 }
 
-export function handleExecuteVote(event: ExecuteVote): void {
+export function handleVoteExecuted(event: VoteExecuted): void {
   let proposalId =
     event.address.toHexString() + '_' + event.params.voteId.toHexString();
   let proposalEntity = WhitelistProposal.load(proposalId);
@@ -150,7 +150,7 @@ export function handleExecuteVote(event: ExecuteVote): void {
   }
 }
 
-export function handleUpdateConfig(event: UpdateConfig): void {
+export function handleConfigUpdated(event: ConfigUpdated): void {
   let packageEntity = WhitelistPackage.load(event.address.toHexString());
   if (packageEntity) {
     packageEntity.participationRequiredPct =

--- a/packages/subgraph/tests/ERC20Voting/erc20Voting.test.ts
+++ b/packages/subgraph/tests/ERC20Voting/erc20Voting.test.ts
@@ -1,6 +1,6 @@
-import { assert, clearStore, test } from 'matchstick-as/assembly/index';
-import { Address, BigInt } from '@graphprotocol/graph-ts';
-import { ERC20VotingPackage, ERC20VotingProposal } from '../../generated/schema';
+import {assert, clearStore, test} from 'matchstick-as/assembly/index';
+import {Address, BigInt} from '@graphprotocol/graph-ts';
+import {ERC20VotingPackage, ERC20VotingProposal} from '../../generated/schema';
 import {
   ADDRESS_ONE,
   DAO_TOKEN_ADDRESS,
@@ -10,23 +10,23 @@ import {
   ADDRESS_ZERO
 } from '../constants';
 import {
-  createNewCastVoteEvent,
-  createNewExecuteVoteEvent,
-  createNewStartVoteEvent,
+  createNewVoteCastEvent,
+  createNewVoteExecutedEvent,
+  createNewVoteStartedEvent,
   createNewTrustedForwarderSetEvent,
-  createNewUpdateConfigEvent,
+  createNewConfigUpdatedEvent,
   getVotesLengthCall
 } from './utils';
 import {
-  handleCastVote,
-  handleExecuteVote,
+  handleVoteCast,
+  handleVoteExecuted,
   handleTrustedForwarderSet,
-  handleUpdateConfig,
-  _handleStartVote
+  handleConfigUpdated,
+  _handleVoteStarted
 } from '../../src/packages/ERC20Voting/erc20Voting';
-import { createDummyAcctions, createGetVoteCall } from '../utils';
+import {createDummyAcctions, createGetVoteCall} from '../utils';
 
-test('Run ERC Voting (handleStartVote) mappings with mock event', () => {
+test('Run ERC Voting (handleVoteStarted) mappings with mock event', () => {
   // create state
   let erc20VotingPackage = new ERC20VotingPackage(
     Address.fromString(VOTING_ADDRESS).toHexString()
@@ -61,7 +61,7 @@ test('Run ERC Voting (handleStartVote) mappings with mock event', () => {
   );
 
   // create event
-  let event = createNewStartVoteEvent(
+  let event = createNewVoteStartedEvent(
     voteId,
     ADDRESS_ONE,
     STRING_DATA,
@@ -69,7 +69,7 @@ test('Run ERC Voting (handleStartVote) mappings with mock event', () => {
   );
 
   // handle event
-  _handleStartVote(event, DAO_ADDRESS, STRING_DATA);
+  _handleVoteStarted(event, DAO_ADDRESS, STRING_DATA);
 
   let entityID =
     Address.fromString(VOTING_ADDRESS).toHexString() +
@@ -128,7 +128,7 @@ test('Run ERC Voting (handleStartVote) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run ERC Voting (handleCastVote) mappings with mock event', () => {
+test('Run ERC Voting (handleVoteCast) mappings with mock event', () => {
   // create state
   let proposalId =
     Address.fromString(VOTING_ADDRESS).toHexString() + '_' + '0x0';
@@ -162,7 +162,7 @@ test('Run ERC Voting (handleCastVote) mappings with mock event', () => {
   );
 
   // create event
-  let event = createNewCastVoteEvent(
+  let event = createNewVoteCastEvent(
     voteId,
     ADDRESS_ONE,
     '2', // Yea
@@ -170,7 +170,7 @@ test('Run ERC Voting (handleCastVote) mappings with mock event', () => {
     VOTING_ADDRESS
   );
 
-  handleCastVote(event);
+  handleVoteCast(event);
 
   // checks
   let entityID = ADDRESS_ONE + '_' + proposalId;
@@ -185,7 +185,7 @@ test('Run ERC Voting (handleCastVote) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run ERC Voting (handleExecuteVote) mappings with mock event', () => {
+test('Run ERC Voting (handleVoteExecuted) mappings with mock event', () => {
   // create state
   let entityID = Address.fromString(VOTING_ADDRESS).toHexString() + '_' + '0x0';
   let erc20VotingProposal = new ERC20VotingProposal(entityID);
@@ -218,10 +218,10 @@ test('Run ERC Voting (handleExecuteVote) mappings with mock event', () => {
   );
 
   // create event
-  let event = createNewExecuteVoteEvent('0', VOTING_ADDRESS);
+  let event = createNewVoteExecutedEvent('0', VOTING_ADDRESS);
 
   // handle event
-  handleExecuteVote(event);
+  handleVoteExecuted(event);
 
   // checks
   assert.fieldEquals('ERC20VotingProposal', entityID, 'id', entityID);
@@ -230,17 +230,17 @@ test('Run ERC Voting (handleExecuteVote) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run ERC Voting (handleUpdateConfig) mappings with mock event', () => {
+test('Run ERC Voting (handleConfigUpdated) mappings with mock event', () => {
   // create state
   let entityID = Address.fromString(VOTING_ADDRESS).toHexString();
   let erc20VotingPackage = new ERC20VotingPackage(entityID);
   erc20VotingPackage.save();
 
   // create event
-  let event = createNewUpdateConfigEvent('1', '2', '3600', VOTING_ADDRESS);
+  let event = createNewConfigUpdatedEvent('1', '2', '3600', VOTING_ADDRESS);
 
   // handle event
-  handleUpdateConfig(event);
+  handleConfigUpdated(event);
 
   // checks
   assert.fieldEquals('ERC20VotingPackage', entityID, 'id', entityID);

--- a/packages/subgraph/tests/ERC20Voting/utils.ts
+++ b/packages/subgraph/tests/ERC20Voting/utils.ts
@@ -1,10 +1,10 @@
-import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts';
-import { createMockedFunction, newMockEvent } from 'matchstick-as';
+import {Address, BigInt, Bytes, ethereum} from '@graphprotocol/graph-ts';
+import {createMockedFunction, newMockEvent} from 'matchstick-as';
 import {
-  StartVote,
-  CastVote,
-  ExecuteVote,
-  UpdateConfig,
+  VoteStarted,
+  VoteCast,
+  VoteExecuted,
+  ConfigUpdated,
   TrustedForwarderSet
 } from '../../generated/templates/ERC20Voting/ERC20Voting';
 
@@ -31,16 +31,16 @@ export function createNewTrustedForwarderSetEvent(
   return newTrustedForwarderSetEvent;
 }
 
-export function createNewStartVoteEvent(
+export function createNewVoteStartedEvent(
   voteId: string,
   creator: string,
   description: string,
   contractAddress: string
-): StartVote {
-  let newStartVoteEvent = changetype<StartVote>(newMockEvent());
+): VoteStarted {
+  let newVoteStartedEvent = changetype<VoteStarted>(newMockEvent());
 
-  newStartVoteEvent.address = Address.fromString(contractAddress);
-  newStartVoteEvent.parameters = [];
+  newVoteStartedEvent.address = Address.fromString(contractAddress);
+  newVoteStartedEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -55,24 +55,24 @@ export function createNewStartVoteEvent(
     ethereum.Value.fromBytes(Bytes.fromUTF8(description))
   );
 
-  newStartVoteEvent.parameters.push(voteIdParam);
-  newStartVoteEvent.parameters.push(creatorParam);
-  newStartVoteEvent.parameters.push(descriptionParam);
+  newVoteStartedEvent.parameters.push(voteIdParam);
+  newVoteStartedEvent.parameters.push(creatorParam);
+  newVoteStartedEvent.parameters.push(descriptionParam);
 
-  return newStartVoteEvent;
+  return newVoteStartedEvent;
 }
 
-export function createNewCastVoteEvent(
+export function createNewVoteCastEvent(
   voteId: string,
   voter: string,
   voterState: string,
   voterWeight: string,
   contractAddress: string
-): CastVote {
-  let newCastVoteEvent = changetype<CastVote>(newMockEvent());
+): VoteCast {
+  let newVoteCastEvent = changetype<VoteCast>(newMockEvent());
 
-  newCastVoteEvent.address = Address.fromString(contractAddress);
-  newCastVoteEvent.parameters = [];
+  newVoteCastEvent.address = Address.fromString(contractAddress);
+  newVoteCastEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -91,22 +91,22 @@ export function createNewCastVoteEvent(
     ethereum.Value.fromSignedBigInt(BigInt.fromString(voterWeight))
   );
 
-  newCastVoteEvent.parameters.push(voteIdParam);
-  newCastVoteEvent.parameters.push(voterParam);
-  newCastVoteEvent.parameters.push(voterStateParam);
-  newCastVoteEvent.parameters.push(stakeParam);
+  newVoteCastEvent.parameters.push(voteIdParam);
+  newVoteCastEvent.parameters.push(voterParam);
+  newVoteCastEvent.parameters.push(voterStateParam);
+  newVoteCastEvent.parameters.push(stakeParam);
 
-  return newCastVoteEvent;
+  return newVoteCastEvent;
 }
 
-export function createNewExecuteVoteEvent(
+export function createNewVoteExecutedEvent(
   voteId: string,
   contractAddress: string
-): ExecuteVote {
-  let newExecuteVoteEvent = changetype<ExecuteVote>(newMockEvent());
+): VoteExecuted {
+  let newVoteExecutedEvent = changetype<VoteExecuted>(newMockEvent());
 
-  newExecuteVoteEvent.address = Address.fromString(contractAddress);
-  newExecuteVoteEvent.parameters = [];
+  newVoteExecutedEvent.address = Address.fromString(contractAddress);
+  newVoteExecutedEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -117,22 +117,22 @@ export function createNewExecuteVoteEvent(
     ethereum.Value.fromBytesArray([Bytes.fromUTF8('')])
   );
 
-  newExecuteVoteEvent.parameters.push(voteIdParam);
-  newExecuteVoteEvent.parameters.push(execResultsParam);
+  newVoteExecutedEvent.parameters.push(voteIdParam);
+  newVoteExecutedEvent.parameters.push(execResultsParam);
 
-  return newExecuteVoteEvent;
+  return newVoteExecutedEvent;
 }
 
-export function createNewUpdateConfigEvent(
+export function createNewConfigUpdatedEvent(
   supportRequiredPct: string,
   participationRequiredPct: string,
   minDuration: string,
   contractAddress: string
-): UpdateConfig {
-  let newUpdateConfigEvent = changetype<UpdateConfig>(newMockEvent());
+): ConfigUpdated {
+  let newConfigUpdatedEvent = changetype<ConfigUpdated>(newMockEvent());
 
-  newUpdateConfigEvent.address = Address.fromString(contractAddress);
-  newUpdateConfigEvent.parameters = [];
+  newConfigUpdatedEvent.address = Address.fromString(contractAddress);
+  newConfigUpdatedEvent.parameters = [];
 
   let participationRequiredPctParam = new ethereum.EventParam(
     'participationRequiredPct',
@@ -147,11 +147,11 @@ export function createNewUpdateConfigEvent(
     ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
   );
 
-  newUpdateConfigEvent.parameters.push(participationRequiredPctParam);
-  newUpdateConfigEvent.parameters.push(supportRequiredPctParam);
-  newUpdateConfigEvent.parameters.push(minDurationParam);
+  newConfigUpdatedEvent.parameters.push(participationRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(supportRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(minDurationParam);
 
-  return newUpdateConfigEvent;
+  return newConfigUpdatedEvent;
 }
 
 // calls

--- a/packages/subgraph/tests/whitelistVoting/utils.ts
+++ b/packages/subgraph/tests/whitelistVoting/utils.ts
@@ -1,10 +1,10 @@
 import {Address, BigInt, Bytes, ethereum} from '@graphprotocol/graph-ts';
 import {createMockedFunction, newMockEvent} from 'matchstick-as';
 import {
-  StartVote,
-  CastVote,
-  ExecuteVote,
-  UpdateConfig,
+  VoteStarted,
+  VoteCast,
+  VoteExecuted,
+  ConfigUpdated,
   AddUsers,
   RemoveUsers,
   TrustedForwarderSet
@@ -33,16 +33,16 @@ export function createNewTrustedForwarderSetEvent(
   return newTrustedForwarderSetEvent;
 }
 
-export function createNewStartVoteEvent(
+export function createNewVoteStartedEvent(
   voteId: string,
   creator: string,
   description: string,
   contractAddress: string
-): StartVote {
-  let newStartVoteEvent = changetype<StartVote>(newMockEvent());
+): VoteStarted {
+  let newVoteStartedEvent = changetype<VoteStarted>(newMockEvent());
 
-  newStartVoteEvent.address = Address.fromString(contractAddress);
-  newStartVoteEvent.parameters = [];
+  newVoteStartedEvent.address = Address.fromString(contractAddress);
+  newVoteStartedEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -57,24 +57,24 @@ export function createNewStartVoteEvent(
     ethereum.Value.fromBytes(Bytes.fromUTF8(description))
   );
 
-  newStartVoteEvent.parameters.push(voteIdParam);
-  newStartVoteEvent.parameters.push(creatorParam);
-  newStartVoteEvent.parameters.push(descriptionParam);
+  newVoteStartedEvent.parameters.push(voteIdParam);
+  newVoteStartedEvent.parameters.push(creatorParam);
+  newVoteStartedEvent.parameters.push(descriptionParam);
 
-  return newStartVoteEvent;
+  return newVoteStartedEvent;
 }
 
-export function createNewCastVoteEvent(
+export function createNewVoteCastEvent(
   voteId: string,
   voter: string,
   voterState: string,
   voterWeight: string,
   contractAddress: string
-): CastVote {
-  let newCastVoteEvent = changetype<CastVote>(newMockEvent());
+): VoteCast {
+  let newVoteCastEvent = changetype<VoteCast>(newMockEvent());
 
-  newCastVoteEvent.address = Address.fromString(contractAddress);
-  newCastVoteEvent.parameters = [];
+  newVoteCastEvent.address = Address.fromString(contractAddress);
+  newVoteCastEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -93,22 +93,22 @@ export function createNewCastVoteEvent(
     ethereum.Value.fromUnsignedBigInt(BigInt.fromString(voterWeight))
   );
 
-  newCastVoteEvent.parameters.push(voteIdParam);
-  newCastVoteEvent.parameters.push(voterParam);
-  newCastVoteEvent.parameters.push(voterStateParam);
-  newCastVoteEvent.parameters.push(voterWeightParam);
+  newVoteCastEvent.parameters.push(voteIdParam);
+  newVoteCastEvent.parameters.push(voterParam);
+  newVoteCastEvent.parameters.push(voterStateParam);
+  newVoteCastEvent.parameters.push(voterWeightParam);
 
-  return newCastVoteEvent;
+  return newVoteCastEvent;
 }
 
-export function createNewExecuteVoteEvent(
+export function createNewVoteExecutedEvent(
   voteId: string,
   contractAddress: string
-): ExecuteVote {
-  let newExecuteVoteEvent = changetype<ExecuteVote>(newMockEvent());
+): VoteExecuted {
+  let newVoteExecutedEvent = changetype<VoteExecuted>(newMockEvent());
 
-  newExecuteVoteEvent.address = Address.fromString(contractAddress);
-  newExecuteVoteEvent.parameters = [];
+  newVoteExecutedEvent.address = Address.fromString(contractAddress);
+  newVoteExecutedEvent.parameters = [];
 
   let voteIdParam = new ethereum.EventParam(
     'voteId',
@@ -119,22 +119,22 @@ export function createNewExecuteVoteEvent(
     ethereum.Value.fromBytesArray([Bytes.fromUTF8('')])
   );
 
-  newExecuteVoteEvent.parameters.push(voteIdParam);
-  newExecuteVoteEvent.parameters.push(execResultsParam);
+  newVoteExecutedEvent.parameters.push(voteIdParam);
+  newVoteExecutedEvent.parameters.push(execResultsParam);
 
-  return newExecuteVoteEvent;
+  return newVoteExecutedEvent;
 }
 
-export function createNewUpdateConfigEvent(
+export function createNewConfigUpdatedEvent(
   participationRequiredPct: string,
   supportRequiredPct: string,
   minDuration: string,
   contractAddress: string
-): UpdateConfig {
-  let newUpdateConfigEvent = changetype<UpdateConfig>(newMockEvent());
+): ConfigUpdated {
+  let newConfigUpdatedEvent = changetype<ConfigUpdated>(newMockEvent());
 
-  newUpdateConfigEvent.address = Address.fromString(contractAddress);
-  newUpdateConfigEvent.parameters = [];
+  newConfigUpdatedEvent.address = Address.fromString(contractAddress);
+  newConfigUpdatedEvent.parameters = [];
 
   let participationRequiredPctParam = new ethereum.EventParam(
     'participationRequiredPct',
@@ -149,11 +149,11 @@ export function createNewUpdateConfigEvent(
     ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
   );
 
-  newUpdateConfigEvent.parameters.push(participationRequiredPctParam);
-  newUpdateConfigEvent.parameters.push(supportRequiredPctParam);
-  newUpdateConfigEvent.parameters.push(minDurationParam);
+  newConfigUpdatedEvent.parameters.push(participationRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(supportRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(minDurationParam);
 
-  return newUpdateConfigEvent;
+  return newConfigUpdatedEvent;
 }
 
 export function createNewAddUsersEvent(

--- a/packages/subgraph/tests/whitelistVoting/utils.ts
+++ b/packages/subgraph/tests/whitelistVoting/utils.ts
@@ -5,8 +5,8 @@ import {
   VoteCast,
   VoteExecuted,
   ConfigUpdated,
-  AddUsers,
-  RemoveUsers,
+  UsersAdded,
+  UsersRemoved,
   TrustedForwarderSet
 } from '../../generated/templates/WhitelistVoting/WhitelistVoting';
 
@@ -156,42 +156,42 @@ export function createNewConfigUpdatedEvent(
   return newConfigUpdatedEvent;
 }
 
-export function createNewAddUsersEvent(
+export function createNewUsersAddedEvent(
   addresses: Address[],
   contractAddress: string
-): AddUsers {
-  let newAddUsersEvent = changetype<AddUsers>(newMockEvent());
+): UsersAdded {
+  let newUsersAddedEvent = changetype<UsersAdded>(newMockEvent());
 
-  newAddUsersEvent.address = Address.fromString(contractAddress);
-  newAddUsersEvent.parameters = [];
+  newUsersAddedEvent.address = Address.fromString(contractAddress);
+  newUsersAddedEvent.parameters = [];
 
   let usersParam = new ethereum.EventParam(
     'users',
     ethereum.Value.fromAddressArray(addresses)
   );
 
-  newAddUsersEvent.parameters.push(usersParam);
+  newUsersAddedEvent.parameters.push(usersParam);
 
-  return newAddUsersEvent;
+  return newUsersAddedEvent;
 }
 
-export function createNewRemoveUsersEvent(
+export function createNewUsersRemovedEvent(
   addresses: Address[],
   contractAddress: string
-): RemoveUsers {
-  let newRemoveUsersEvent = changetype<RemoveUsers>(newMockEvent());
+): UsersRemoved {
+  let newUsersRemovedEvent = changetype<UsersRemoved>(newMockEvent());
 
-  newRemoveUsersEvent.address = Address.fromString(contractAddress);
-  newRemoveUsersEvent.parameters = [];
+  newUsersRemovedEvent.address = Address.fromString(contractAddress);
+  newUsersRemovedEvent.parameters = [];
 
   let usersParam = new ethereum.EventParam(
     'users',
     ethereum.Value.fromAddressArray(addresses)
   );
 
-  newRemoveUsersEvent.parameters.push(usersParam);
+  newUsersRemovedEvent.parameters.push(usersParam);
 
-  return newRemoveUsersEvent;
+  return newUsersRemovedEvent;
 }
 
 // calls

--- a/packages/subgraph/tests/whitelistVoting/whitelistVoting.test.ts
+++ b/packages/subgraph/tests/whitelistVoting/whitelistVoting.test.ts
@@ -15,20 +15,20 @@ import {
   ADDRESS_ZERO
 } from '../constants';
 import {
-  createNewAddUsersEvent,
+  createNewUsersAddedEvent,
   createNewVoteCastEvent,
   createNewVoteExecutedEvent,
-  createNewRemoveUsersEvent,
+  createNewUsersRemovedEvent,
   createNewVoteStartedEvent,
   createNewTrustedForwarderSetEvent,
   createNewConfigUpdatedEvent,
   getVotesLengthCall
 } from './utils';
 import {
-  handleAddUsers,
+  handleUsersAdded,
   handleVoteCast,
   handleVoteExecuted,
-  handleRemoveUsers,
+  handleUsersRemoved,
   handleTrustedForwarderSet,
   handleConfigUpdated,
   _handleVoteStarted
@@ -214,17 +214,17 @@ test('Run Whitelist Voting (handleConfigUpdated) mappings with mock event', () =
   clearStore();
 });
 
-test('Run Whitelist Voting (handleAddUsers) mappings with mock event', () => {
+test('Run Whitelist Voting (handleUsersAdded) mappings with mock event', () => {
   let userArray = [
     Address.fromString(ADDRESS_ONE),
     Address.fromString(ADDRESS_TWO)
   ];
 
   // create event
-  let event = createNewAddUsersEvent(userArray, VOTING_ADDRESS);
+  let event = createNewUsersAddedEvent(userArray, VOTING_ADDRESS);
 
   // handle event
-  handleAddUsers(event);
+  handleUsersAdded(event);
 
   // checks
   assert.fieldEquals(
@@ -243,7 +243,7 @@ test('Run Whitelist Voting (handleAddUsers) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run Whitelist Voting (RemoveUsers) mappings with mock event', () => {
+test('Run Whitelist Voting (UsersRemoved) mappings with mock event', () => {
   // create state
   let userArray = [
     Address.fromString(ADDRESS_ONE),
@@ -257,10 +257,10 @@ test('Run Whitelist Voting (RemoveUsers) mappings with mock event', () => {
   }
 
   // create event
-  let event = createNewRemoveUsersEvent([userArray[1]], VOTING_ADDRESS);
+  let event = createNewUsersRemovedEvent([userArray[1]], VOTING_ADDRESS);
 
   // handle event
-  handleRemoveUsers(event);
+  handleUsersRemoved(event);
 
   // checks
   assert.fieldEquals(

--- a/packages/subgraph/tests/whitelistVoting/whitelistVoting.test.ts
+++ b/packages/subgraph/tests/whitelistVoting/whitelistVoting.test.ts
@@ -16,22 +16,22 @@ import {
 } from '../constants';
 import {
   createNewAddUsersEvent,
-  createNewCastVoteEvent,
-  createNewExecuteVoteEvent,
+  createNewVoteCastEvent,
+  createNewVoteExecutedEvent,
   createNewRemoveUsersEvent,
-  createNewStartVoteEvent,
+  createNewVoteStartedEvent,
   createNewTrustedForwarderSetEvent,
-  createNewUpdateConfigEvent,
+  createNewConfigUpdatedEvent,
   getVotesLengthCall
 } from './utils';
 import {
   handleAddUsers,
-  handleCastVote,
-  handleExecuteVote,
+  handleVoteCast,
+  handleVoteExecuted,
   handleRemoveUsers,
   handleTrustedForwarderSet,
-  handleUpdateConfig,
-  _handleStartVote
+  handleConfigUpdated,
+  _handleVoteStarted
 } from '../../src/packages/whitelist/whitelistVoting';
 import {createDummyAcctions, createGetVoteCall} from '../utils';
 
@@ -43,7 +43,7 @@ let supportRequiredPct = '1000';
 let participationRequired = '500';
 let votingPower = '1000';
 
-test('Run Whitelist Voting (handleStartVote) mappings with mock event', () => {
+test('Run Whitelist Voting (handleVoteStarted) mappings with mock event', () => {
   // create state
   let erc20VotingPackage = new WhitelistPackage(
     Address.fromString(VOTING_ADDRESS).toHexString()
@@ -72,7 +72,7 @@ test('Run Whitelist Voting (handleStartVote) mappings with mock event', () => {
   );
 
   // create event
-  let event = createNewStartVoteEvent(
+  let event = createNewVoteStartedEvent(
     voteId,
     ADDRESS_ONE,
     STRING_DATA,
@@ -80,7 +80,7 @@ test('Run Whitelist Voting (handleStartVote) mappings with mock event', () => {
   );
 
   // handle event
-  _handleStartVote(event, DAO_ADDRESS, STRING_DATA);
+  _handleVoteStarted(event, DAO_ADDRESS, STRING_DATA);
 
   let entityID =
     Address.fromString(VOTING_ADDRESS).toHexString() +
@@ -122,7 +122,7 @@ test('Run Whitelist Voting (handleStartVote) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run Whitelist Voting (handleCastVote) mappings with mock event', () => {
+test('Run Whitelist Voting (handleVoteCast) mappings with mock event', () => {
   // create state
   let proposalId =
     Address.fromString(VOTING_ADDRESS).toHexString() + '_' + '0x0';
@@ -149,7 +149,7 @@ test('Run Whitelist Voting (handleCastVote) mappings with mock event', () => {
   );
 
   // create event
-  let event = createNewCastVoteEvent(
+  let event = createNewVoteCastEvent(
     voteId,
     ADDRESS_ONE,
     '2',
@@ -157,7 +157,7 @@ test('Run Whitelist Voting (handleCastVote) mappings with mock event', () => {
     VOTING_ADDRESS
   );
 
-  handleCastVote(event);
+  handleVoteCast(event);
 
   // checks
   let entityID = ADDRESS_ONE + '_' + proposalId;
@@ -169,17 +169,17 @@ test('Run Whitelist Voting (handleCastVote) mappings with mock event', () => {
   clearStore();
 });
 
-test('Run Whitelist Voting (handleExecuteVote) mappings with mock event', () => {
+test('Run Whitelist Voting (handleVoteExecuted) mappings with mock event', () => {
   // create state
   let entityID = Address.fromString(VOTING_ADDRESS).toHexString() + '_' + '0x0';
   let erc20VotingProposal = new WhitelistProposal(entityID);
   erc20VotingProposal.save();
 
   // create event
-  let event = createNewExecuteVoteEvent('0', VOTING_ADDRESS);
+  let event = createNewVoteExecutedEvent('0', VOTING_ADDRESS);
 
   // handle event
-  handleExecuteVote(event);
+  handleVoteExecuted(event);
 
   // checks
   assert.fieldEquals('WhitelistProposal', entityID, 'id', entityID);
@@ -188,17 +188,17 @@ test('Run Whitelist Voting (handleExecuteVote) mappings with mock event', () => 
   clearStore();
 });
 
-test('Run Whitelist Voting (handleUpdateConfig) mappings with mock event', () => {
+test('Run Whitelist Voting (handleConfigUpdated) mappings with mock event', () => {
   // create state
   let entityID = Address.fromString(VOTING_ADDRESS).toHexString();
   let erc20VotingPackage = new WhitelistPackage(entityID);
   erc20VotingPackage.save();
 
   // create event
-  let event = createNewUpdateConfigEvent('2', '1', '3600', VOTING_ADDRESS);
+  let event = createNewConfigUpdatedEvent('2', '1', '3600', VOTING_ADDRESS);
 
   // handle event
-  handleUpdateConfig(event);
+  handleConfigUpdated(event);
 
   // checks
   assert.fieldEquals('WhitelistPackage', entityID, 'id', entityID);


### PR DESCRIPTION
## Description

- Added missing NatSpec formatting
- Changed events name to comply with the NatSpec naming convention for events (Object + verb in past participle form)
- Added missing @params in the method's signature
- Modified double comments `//` for triple comments `///`
- Improved voting tests by expecting the `VoteExecuted` event to be emitted

Task: [APP-268](https://aragonassociation.atlassian.net/browse/APP-268), [APP-66](https://aragonassociation.atlassian.net/browse/APP-66)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.