### PR TITLE
fix: build and deploy job for subgraph deployment

### DIFF
--- a/.github/workflows/subgraph-deploy.yaml
+++ b/.github/workflows/subgraph-deploy.yaml
@@ -81,7 +81,7 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     needs: [prepare]
-    if: needs.prepare.outputs.environment != ''
+    if: needs.prepare.outputs.environment != '' && contains(github.event.pull_request.labels.*.name, 'subgraph:')
     environment: ${{ needs.prepare.outputs.environment }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Fix the `build-deploy` job in to run only when a `subgraph:*` label is set.

Task: [DOPS-322](https://aragonassociation.atlassian.net/browse/DOPS-322)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.