### PR TITLE
fix: combines transfers into one type

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `members` to `ERC20VotingPackage`.
 - Added `lastUpdated` to `ERC20VotingVoter`.
 - added `voteCount` to both `ERC20VotingProposal` and `AllowlistProposal`.
+- addes type field to `VaultTransfer` to differntiate between deposits and withdraws
 
 ### Changed
 
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `manifest`, `registry`, `registry.test`.
 - Refactored import statements.
 - Refactored event names.
+- Refacotred `deposits` and `withdraws` into one field `transfers`
+- Refactored `VaultWithdraw` and `VaultDeposit` into one type `VaultTransfer`
 
 ## v0.2.0-alpha
 

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -54,28 +54,25 @@ type Action @entity {
 
 # Treasury
 
-type VaultWithdraw @entity {
+enum TransferType {
+  Withdraw
+  Deposit
+}
+
+type VaultTransfer @entity {
   id: ID!
   dao: Dao!
   token: ERC20Token
-  to: Bytes!
+  sender: Bytes
+  to: Bytes
   amount: BigInt!
   reference: String!
   transaction: String!
-  proposal: Proposal!
+  proposal: Proposal
   createdAt: BigInt!
+  type: TransferType!
 }
 
-type VaultDeposit @entity {
-  id: ID!
-  dao: Dao!
-  token: ERC20Token!
-  sender: Bytes!
-  amount: BigInt!
-  reference: String!
-  transaction: String!
-  createdAt: BigInt!
-}
 
 # Dao
 
@@ -87,8 +84,7 @@ type Dao @entity {
   createdAt: BigInt!
   token: ERC20Token!
   actions: [Action!]! @derivedFrom(field: "dao")
-  deposits: [VaultDeposit!]! @derivedFrom(field: "dao")
-  withdraws: [VaultWithdraw!]! @derivedFrom(field: "dao")
+  transfers: [VaultTransfers]! @derivedFrom(field: "dao")
   balances: [Balance!] @derivedFrom(field: "dao")
   contractPermissionIds: [ContractPermissionId!]! @derivedFrom(field: "dao")
   permissions: [Permission!]! @derivedFrom(field: "dao")

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -73,7 +73,6 @@ type VaultTransfer @entity {
   type: TransferType!
 }
 
-
 # Dao
 
 type Dao @entity {
@@ -84,7 +83,7 @@ type Dao @entity {
   createdAt: BigInt!
   token: ERC20Token!
   actions: [Action!]! @derivedFrom(field: "dao")
-  transfers: [VaultTransfers]! @derivedFrom(field: "dao")
+  transfers: [VaultTransfer!]! @derivedFrom(field: "dao")
   balances: [Balance!] @derivedFrom(field: "dao")
   contractPermissionIds: [ContractPermissionId!]! @derivedFrom(field: "dao")
   permissions: [Permission!]! @derivedFrom(field: "dao")

--- a/packages/subgraph/src/dao/dao.ts
+++ b/packages/subgraph/src/dao/dao.ts
@@ -1,4 +1,4 @@
-import {Address, Bytes, store} from '@graphprotocol/graph-ts';
+import { Address, Bytes, store } from '@graphprotocol/graph-ts';
 
 import {
   DAO as DAOContract,
@@ -12,15 +12,14 @@ import {
 } from '../../generated/templates/DaoTemplate/DAO';
 import {
   Dao,
-  VaultDeposit,
-  VaultWithdraw,
   ContractPermissionId,
-  Permission
+  Permission,
+  VaultTransfer
 } from '../../generated/schema';
 
-import {ADDRESS_ZERO} from '../utils/constants';
-import {handleERC20Token, updateBalance} from '../utils/tokens';
-import {addPackage, decodeWithdrawParams, removePackage} from './utils';
+import { ADDRESS_ZERO } from '../utils/constants';
+import { handleERC20Token, updateBalance } from '../utils/tokens';
+import { addPackage, decodeWithdrawParams, removePackage } from './utils';
 
 export function handleMetadataSet(event: MetadataSet): void {
   let daoId = event.address.toHexString();
@@ -59,7 +58,7 @@ export function handleDeposited(event: Deposited): void {
     event.block.timestamp
   );
 
-  let entity = new VaultDeposit(depositId);
+  let entity = new VaultTransfer(depositId);
   entity.dao = daoId;
   entity.token = tokenId;
   entity.sender = event.params.sender;
@@ -67,7 +66,9 @@ export function handleDeposited(event: Deposited): void {
   entity.reference = event.params._reference;
   entity.transaction = event.transaction.hash.toHexString();
   entity.createdAt = event.block.timestamp;
+  entity.type = "Deposit";
   entity.save();
+
 }
 
 export function handleNativeTokenDeposited(event: NativeTokenDeposited): void {
@@ -79,7 +80,7 @@ export function handleNativeTokenDeposited(event: NativeTokenDeposited): void {
     '_' +
     event.transactionLogIndex.toHexString();
 
-  let entity = new VaultDeposit(id);
+  let entity = new VaultTransfer(id);
   let balanceId = daoId + '_' + ADDRESS_ZERO;
 
   // handle token
@@ -101,6 +102,7 @@ export function handleNativeTokenDeposited(event: NativeTokenDeposited): void {
   entity.reference = 'Eth deposit';
   entity.transaction = event.transaction.hash.toHexString();
   entity.createdAt = event.block.timestamp;
+  entity.type = "Deposit";
   entity.save();
 }
 
@@ -162,7 +164,7 @@ export function handleExecuted(event: Executed): void {
         '_' +
         index.toString();
 
-      let vaultWithdrawEntity = new VaultWithdraw(withdrawId);
+      let vaultWithdrawEntity = new VaultTransfer(withdrawId);
       vaultWithdrawEntity.dao = daoId;
       vaultWithdrawEntity.token = tokenId;
       vaultWithdrawEntity.to = withdrawParams.to;
@@ -171,6 +173,7 @@ export function handleExecuted(event: Executed): void {
       vaultWithdrawEntity.proposal = proposalId;
       vaultWithdrawEntity.transaction = event.transaction.hash.toHexString();
       vaultWithdrawEntity.createdAt = event.block.timestamp;
+      vaultWithdrawEntity.type = "Withdraw";
       vaultWithdrawEntity.save();
     }
   }

--- a/packages/subgraph/tests/dao/dao.test.ts
+++ b/packages/subgraph/tests/dao/dao.test.ts
@@ -65,9 +65,9 @@ test('Run dao (handleDeposited) for native token mappings with mock event', () =
   handleNativeTokenDeposited(newEvent);
 
   // checks
-  assert.fieldEquals('VaultDeposit', entityID, 'id', entityID);
-  assert.fieldEquals('VaultDeposit', entityID, 'sender', ADDRESS_ONE);
-  assert.fieldEquals('VaultDeposit', entityID, 'amount', ONE_ETH);
+  assert.fieldEquals('VaultTransfer', entityID, 'id', entityID);
+  assert.fieldEquals('VaultTransfer', entityID, 'sender', ADDRESS_ONE);
+  assert.fieldEquals('VaultTransfer', entityID, 'amount', ONE_ETH);
 
   clearStore();
 });
@@ -149,22 +149,22 @@ test('Run dao (handleDeposited) for Token mappings with mock event', () => {
     HALF_ETH
   );
   // checks Deposit
-  assert.fieldEquals('VaultDeposit', entityID, 'id', entityID);
+  assert.fieldEquals('VaultTransfer', entityID, 'id', entityID);
   assert.fieldEquals(
-    'VaultDeposit',
+    'VaultTransfer',
     entityID,
     'dao',
     Address.fromString(DAO_ADDRESS).toHexString()
   );
-  assert.fieldEquals('VaultDeposit', entityID, 'sender', ADDRESS_ONE);
+  assert.fieldEquals('VaultTransfer', entityID, 'sender', ADDRESS_ONE);
   assert.fieldEquals(
-    'VaultDeposit',
+    'VaultTransfer',
     entityID,
     'token',
     Address.fromString(DAO_TOKEN_ADDRESS).toHexString()
   );
-  assert.fieldEquals('VaultDeposit', entityID, 'amount', ONE_ETH);
-  assert.fieldEquals('VaultDeposit', entityID, 'reference', STRING_DATA);
+  assert.fieldEquals('VaultTransfer', entityID, 'amount', ONE_ETH);
+  assert.fieldEquals('VaultTransfer', entityID, 'reference', STRING_DATA);
 
   clearStore();
 });
@@ -207,41 +207,41 @@ test('Run dao (handleExecuted) for Token mappings with mock event', () => {
     event.transactionLogIndex.toHexString() +
     '_' +
     '0';
-  assert.fieldEquals('VaultWithdraw', entityID, 'id', entityID);
+  assert.fieldEquals('VaultTransfer', entityID, 'id', entityID);
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'dao',
     Address.fromHexString(DAO_ADDRESS).toHexString()
   );
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'token',
     Address.fromHexString(DAO_TOKEN_ADDRESS).toHexString()
   );
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'to',
     Address.fromHexString(ADDRESS_ONE).toHexString()
   );
-  assert.fieldEquals('VaultWithdraw', entityID, 'amount', '1');
+  assert.fieldEquals('VaultTransfer', entityID, 'amount', '1');
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'reference',
     Bytes.fromUTF8(STRING_DATA).toString()
   );
-  assert.fieldEquals('VaultWithdraw', entityID, 'proposal', proposalId);
+  assert.fieldEquals('VaultTransfer', entityID, 'proposal', proposalId);
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'transaction',
     event.transaction.hash.toHexString()
   );
   assert.fieldEquals(
-    'VaultWithdraw',
+    'VaultTransfer',
     entityID,
     'createdAt',
     event.block.timestamp.toString()


### PR DESCRIPTION
## Description

Previously Withdraws and Deposits were handles by different types and exposed as 2 different fields in the DAO.
These are now combines into 1 field (`transfers`)  and are differentiated by the field `type`.

Task: [APP-962](https://aragonassociation.atlassian.net/browse/APP-962)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.