### PR TITLE
Fix to prevent double initialization of upgradeable plugins

### DIFF
--- a/packages/contracts/contracts/plugin/examples/count/CounterV2.sol
+++ b/packages/contracts/contracts/plugin/examples/count/CounterV2.sol
@@ -34,7 +34,7 @@ contract CounterV2 is PluginUUPSUpgradeable {
         MultiplyHelper _multiplyHelper,
         uint256 _count,
         uint256 _newVariable
-    ) external initializer {
+    ) external reinitializer(2) {
         __PluginUpgradeable_init(_dao);
 
         count = _count;
@@ -49,7 +49,6 @@ contract CounterV2 is PluginUUPSUpgradeable {
     /// @notice Sets a the new variable that was added in V2.
     /// @param _newVariable The new variable.
     /// @dev This gets called when a dao already has `CounterV1` installed and updates to this verison `CounterV2`. For these DAOs, this `setNewVariable` can only be called once which is achieved by `reinitializer(2)`.
-    // TODO: This might still be called by daos that install CounterV2 for the first time, calls initialize and then calls setNewVariable.
     function setNewVariable(uint256 _newVariable) external reinitializer(2) {
         newVariable = _newVariable;
     }

--- a/packages/contracts/contracts/test/plugin-mock/UUPSUpgradeable/PluginUUPSUpgradeableV2Mock.sol
+++ b/packages/contracts/contracts/test/plugin-mock/UUPSUpgradeable/PluginUUPSUpgradeableV2Mock.sol
@@ -17,7 +17,7 @@ contract PluginUUPSUpgradeableV2Mock is PluginUUPSUpgradeable {
         uint256 _num,
         address _helper,
         string memory _str
-    ) external initializer {
+    ) external reinitializer(2) {
         __DaoAuthorizableUpgradeable_init(_dao);
         num = _num;
         helper = _helper;


### PR DESCRIPTION
## Description

This bug fix was found while working on task [APP-1077](https://aragonassociation.atlassian.net/browse/APP-1077) and prevents double-initialization of freshly installed plugins with `version > 1` that use setters for the initialization of storage variables.
This fix replaces the `initializer` modifier by the `reinitializer(uint8 version)` modifier for the `initialize` functions to prevent the setters to be called after `initialize` was executed.

Tests for this fix should be added together with [APP-1077](https://aragonassociation.atlassian.net/browse/APP-1077) to the `Counter` and `PluginUUPSUpgradeableMock` examples.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.