### PR TITLE
Added missing index file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ yarn-error.log*
 deployments
 
 # generated
-03-reference-guide
+packages/contracts/docs/core/03-reference-guide/*
+!packages/contracts/docs/core/03-reference-guide/index.md
 generated
 subgraph.yaml
 .bin

--- a/packages/contracts/docs/core/03-reference-guide/index.md
+++ b/packages/contracts/docs/core/03-reference-guide/index.md
@@ -1,0 +1,7 @@
+---
+title: Reference
+---
+
+## Reference Guide
+
+This reference is automatically generated from the Solidity contracts [NatSpec comments](https://docs.soliditylang.org/en/develop/natspec-format.html) of the latest version of the [aragon/core GitHub](https://github.com/aragon/core) repository.


### PR DESCRIPTION
## Description

An index file was missing in the docs folder because it was ignored `packages/contracts/docs/core/03-reference-guide/index.md`.
