### PR TITLE
add mint for tokens in the initialize.

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an abstract `ERC165RegistryBase` `Component` to register contracts by their address based on their ERC165 interface ID.
 - Added a concrete `ERC165Registry` implementation.
 - Added ENS support for `PluginRepoRegistry`.
-- Added Mint possibility in the `GovernanceERC20`'s initialize function.
+- Added minting functionality to the `initialize` function of `GovernanceERC20`.
 
 ### Changed
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `deepEqual` overwrite of `equal` property in Chai Assertion used for testing of emitted events.
 - Removed `ERC165Registry`.
 - Removed `Component` and `MetaTxComponent`.
-- Removed `MerkleMinter` Deployment from `ERC20VotingSetup`
+- Removed `MerkleMinter` deployment from `ERC20VotingSetup`.
 
 ## v0.2.0-alpha
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an abstract `ERC165RegistryBase` `Component` to register contracts by their address based on their ERC165 interface ID.
 - Added a concrete `ERC165Registry` implementation.
 - Added ENS support for `PluginRepoRegistry`.
+- Added Mint possibility in the `GovernanceERC20`'s initialize function.
 
 ### Changed
 
@@ -73,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `deepEqual` overwrite of `equal` property in Chai Assertion used for testing of emitted events.
 - Removed `ERC165Registry`.
 - Removed `Component` and `MetaTxComponent`.
+- Removed `MerkleMinter` Deployment from `ERC20VotingSetup`
 
 ## v0.2.0-alpha
 

--- a/packages/contracts/contracts/factory/TokenFactory.sol
+++ b/packages/contracts/contracts/factory/TokenFactory.sol
@@ -69,7 +69,7 @@ contract TokenFactory {
     /// @notice Creates a new `GovernanceERC20` token or a `GovernanceWrappedERC20` from an existing [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token depending on the address used in the `TokenConfig` provided.
     /// @param _managingDao The address of the DAO managing the token.
     /// @param _tokenConfig The token configuration struct containing the name, and symbol of the token to be create, but also an address. For `address(0)`, a new governance token is created. For any other address pointing to an [ERC-20](https://eips.ethereum.org/EIPS/eip-20)-compatible contract, a wrapped governance token is created.
-    /// @param _mintSettings The token mint configuration struct containing the `receivers` and `amounts`.
+    /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
     /// @return ERC20VotesUpgradeable The address of the created token.
     /// @return MerkleMinter The `MerkleMinter` contract address being used to mint token address(zero address in case passed token addr was not zero)
     function createToken(

--- a/packages/contracts/contracts/factory/TokenFactory.sol
+++ b/packages/contracts/contracts/factory/TokenFactory.sol
@@ -39,8 +39,12 @@ contract TokenFactory {
     /// @param token [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token address.
     /// @param minter The `MerkleMinter` contract minting the new token.
     /// @param distributor The `MerkleDistibutor` contract distributing the new token.
-    event TokenCreated(IERC20Upgradeable token, MerkleMinter minter, IMerkleDistributor distributor);
-    
+    event TokenCreated(
+        IERC20Upgradeable token,
+        MerkleMinter minter,
+        IMerkleDistributor distributor
+    );
+
     /// @notice Emitted when an existing token is passed and wrapped one is created.
     /// @param token GovernanceWrappedERC20 token address
     event WrappedToken(GovernanceWrappedERC20 token);
@@ -65,13 +69,13 @@ contract TokenFactory {
     /// @notice Creates a new `GovernanceERC20` token or a `GovernanceWrappedERC20` from an existing [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token depending on the address used in the `TokenConfig` provided.
     /// @param _managingDao The address of the DAO managing the token.
     /// @param _tokenConfig The token configuration struct containing the name, and symbol of the token to be create, but also an address. For `address(0)`, a new governance token is created. For any other address pointing to an [ERC-20](https://eips.ethereum.org/EIPS/eip-20)-compatible contract, a wrapped governance token is created.
-    /// @param _mintConfig The token mint configuration struct containing the `receivers` and `amounts`.
+    /// @param _mintSettings The token mint configuration struct containing the `receivers` and `amounts`.
     /// @return ERC20VotesUpgradeable The address of the created token.
     /// @return MerkleMinter The `MerkleMinter` contract address being used to mint token address(zero address in case passed token addr was not zero)
     function createToken(
         DAO _managingDao,
         TokenConfig calldata _tokenConfig,
-        MintConfig calldata _mintConfig
+        GovernanceERC20.MintSettings calldata _mintSettings
     ) external returns (ERC20VotesUpgradeable, MerkleMinter) {
         address token = _tokenConfig.addr;
 
@@ -99,7 +103,7 @@ contract TokenFactory {
         }
 
         token = governanceERC20Base.clone();
-        GovernanceERC20(token).initialize(_managingDao, _tokenConfig.name, _tokenConfig.symbol);
+        GovernanceERC20(token).initialize(_managingDao, _tokenConfig.name, _tokenConfig.symbol, _mintSettings);
 
         // Clone and initialize a `MerkleMinter`
         address merkleMinter = merkleMinterBase.clone();
@@ -110,29 +114,11 @@ contract TokenFactory {
         );
 
         // Emit the event
-        emit TokenCreated(
-            IERC20Upgradeable(token),
-            MerkleMinter(merkleMinter),
-            distributorBase
-        );
+        emit TokenCreated(IERC20Upgradeable(token), MerkleMinter(merkleMinter), distributorBase);
 
         bytes32 tokenMintPermission = GovernanceERC20(token).MINT_PERMISSION_ID();
         bytes32 merkleMintPermission = MerkleMinter(merkleMinter).MERKLE_MINT_PERMISSION_ID();
-
-        // Grant the permission to mint to the token factory (`address(this)`).
-        _managingDao.grant(token, address(this), tokenMintPermission);
-
-        for (uint256 i = 0; i < _mintConfig.receivers.length; i++) {
-            // allow minting to treasury
-            address receiver = _mintConfig.receivers[i] == address(0)
-                ? address(_managingDao)
-                : _mintConfig.receivers[i];
-            IERC20MintableUpgradeable(token).mint(receiver, _mintConfig.amounts[i]);
-        }
-
-        // Revoke the mint permission from the token factory (`address(this)`).
-        _managingDao.revoke(token, address(this), tokenMintPermission);
-
+        
         // Grant the managing DAO permission to directly mint tokens to an receiving address.
         _managingDao.grant(token, address(_managingDao), tokenMintPermission);
 
@@ -147,7 +133,12 @@ contract TokenFactory {
     function setupBases() private {
         distributorBase = new MerkleDistributor();
         governanceERC20Base = address(
-            new GovernanceERC20(IDAO(address(0)), "baseName", "baseSymbol")
+            new GovernanceERC20(
+                IDAO(address(0)),
+                "baseName",
+                "baseSymbol",
+                GovernanceERC20.MintSettings(new address[](0), new uint256[](0))
+            )
         );
         governanceWrappedERC20Base = address(
             new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "baseName", "baseSymbol")

--- a/packages/contracts/contracts/tokens/GovernanceERC20.sol
+++ b/packages/contracts/contracts/tokens/GovernanceERC20.sol
@@ -48,7 +48,8 @@ contract GovernanceERC20 is
     /// @param _dao The managing DAO.
     /// @param _name The name of the wrapped token.
     /// @param _symbol The symbol fo the wrapped token.
-    /// @param _mintSettings The initial mint settings
+    /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
+    /// @dev The lengths of `receivers` and `amounts` must match.
     function initialize(
         IDAO _dao,
         string memory _name,

--- a/packages/contracts/contracts/tokens/GovernanceERC20.sol
+++ b/packages/contracts/contracts/tokens/GovernanceERC20.sol
@@ -60,8 +60,12 @@ contract GovernanceERC20 is
         __ERC20Permit_init(_name);
         __DaoAuthorizableUpgradeable_init(_dao);
 
-        for(uint i = 0; i < _mintSettings.receivers.length; i++) {
+        for(uint256 i = 0; i < _mintSettings.receivers.length;) {
             _mint(_mintSettings.receivers[i], _mintSettings.amounts[i]);
+            
+            unchecked {
+                i++;
+            }
         }
     }
 

--- a/packages/contracts/contracts/tokens/GovernanceERC20.sol
+++ b/packages/contracts/contracts/tokens/GovernanceERC20.sol
@@ -60,8 +60,6 @@ contract GovernanceERC20 is
         __ERC20Permit_init(_name);
         __DaoAuthorizableUpgradeable_init(_dao);
 
-        // NOTE: It's deployer's responsibility to ensure that
-        // receivers.length matches amounts.length
         for(uint i = 0; i < _mintSettings.receivers.length; i++) {
             _mint(_mintSettings.receivers[i], _mintSettings.amounts[i]);
         }

--- a/packages/contracts/contracts/tokens/GovernanceERC20.sol
+++ b/packages/contracts/contracts/tokens/GovernanceERC20.sol
@@ -26,29 +26,44 @@ contract GovernanceERC20 is
     /// @notice The permission identifier to mint new tokens
     bytes32 public constant MINT_PERMISSION_ID = keccak256("MINT_PERMISSION");
     
+    struct MintSettings {
+        address[] receivers;
+        uint256[] amounts;
+    }
+
     /// @param _dao The managing DAO.
     /// @param _name The name of the wrapped token.
     /// @param _symbol The symbol fo the wrapped token.
+    /// @param _mintSettings The initial mint settings
     constructor(
         IDAO _dao,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        MintSettings memory _mintSettings
     ) {
-        initialize(_dao, _name, _symbol);
+        initialize(_dao, _name, _symbol, _mintSettings);
     }
 
     /// @notice Initializes the GovernanceERC20.
     /// @param _dao The managing DAO.
     /// @param _name The name of the wrapped token.
     /// @param _symbol The symbol fo the wrapped token.
+    /// @param _mintSettings The initial mint settings
     function initialize(
         IDAO _dao,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        MintSettings memory _mintSettings
     ) public initializer {
         __ERC20_init(_name, _symbol);
         __ERC20Permit_init(_name);
         __DaoAuthorizableUpgradeable_init(_dao);
+
+        // NOTE: It's deployer's responsibility to ensure that
+        // receivers.length matches amounts.length
+        for(uint i = 0; i < _mintSettings.receivers.length; i++) {
+            _mint(_mintSettings.receivers[i], _mintSettings.amounts[i]);
+        }
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.

--- a/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
@@ -299,7 +299,6 @@ contract ERC20VotingSetup is PluginSetup {
         // calls dao for the permissions, we might decide to include the below always as it will be
         // more gas less than checking isGovernanceERC20..
         if(isGovernanceERC20) {
-            bytes32 tokenMintPermission = GovernanceERC20(token).MINT_PERMISSION_ID();
             permissions[3] = PermissionLib.ItemMultiTarget(
                 PermissionLib.Operation.Revoke,
                 token,

--- a/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
@@ -305,7 +305,7 @@ contract ERC20VotingSetup is PluginSetup {
                 token,
                 _dao,
                 NO_ORACLE,
-                tokenMintPermission
+                GovernanceERC20(token).MINT_PERMISSION_ID()
             );
         }
     }

--- a/packages/contracts/test/core/dao.ts
+++ b/packages/contracts/test/core/dao.ts
@@ -56,7 +56,10 @@ describe('DAO', function () {
     await dao.initialize(dummyMetadata1, ownerAddress, dummyAddress1);
 
     const Token = await ethers.getContractFactory('GovernanceERC20');
-    token = await Token.deploy(dao.address, 'GOV', 'GOV');
+    token = await Token.deploy(dao.address, 'GOV', 'GOV', {
+      receivers: [],
+      amounts: [],
+    });
 
     // Grant permissions
     await Promise.all([

--- a/packages/contracts/test/factory/token-factory.ts
+++ b/packages/contracts/test/factory/token-factory.ts
@@ -40,13 +40,22 @@ describe('Core: TokenFactory', () => {
     const GovernanceBaseFactory = await smock.mock<GovernanceERC20__factory>(
       'GovernanceERC20'
     );
-    governanceBase = await GovernanceBaseFactory.deploy(ethers.constants.AddressZero, "name", "symbol");
+    governanceBase = await GovernanceBaseFactory.deploy(
+      ethers.constants.AddressZero,
+      'name',
+      'symbol',
+      {receivers: [], amounts: []}
+    );
 
     const GovernanceWrappedBaseFactory =
       await smock.mock<GovernanceWrappedERC20__factory>(
         'GovernanceWrappedERC20'
       );
-    governanceWrappedBase = await GovernanceWrappedBaseFactory.deploy(ethers.constants.AddressZero, "name", "symbol");
+    governanceWrappedBase = await GovernanceWrappedBaseFactory.deploy(
+      ethers.constants.AddressZero,
+      'name',
+      'symbol'
+    );
 
     const MerkleMinterBaseFactory = await smock.mock<MerkleMinter__factory>(
       'MerkleMinter'
@@ -110,13 +119,13 @@ describe('Core: TokenFactory', () => {
         amounts: [1],
       };
 
-      const tx = await tokenFactory.callStatic.createToken(
+      const [wrappedToken, merkleMinter] = await tokenFactory.callStatic.createToken(
         dao.address,
         config,
         mintConfig
       );
 
-      expect(tx[0]).not.to.be.eq(governanceWrappedBase.address);
+      expect(wrappedToken).not.to.be.eq(governanceWrappedBase.address);
     });
 
     it('should return MerkleMinter with 0x0', async () => {
@@ -250,8 +259,10 @@ describe('Core: TokenFactory', () => {
         symbol: 'FT',
       };
 
+      const mintAddress = '0x0000000000000000000000000000000000000001'
+
       const mintConfig: MintConfig = {
-        receivers: ['0x0000000000000000000000000000000000000000'],
+        receivers: [mintAddress],
         amounts: [1],
       };
 
@@ -273,7 +284,7 @@ describe('Core: TokenFactory', () => {
         .to.emit(erc20Contract, 'Transfer')
         .withArgs(
           '0x0000000000000000000000000000000000000000',
-          dao.address,
+          mintConfig.receivers[0],
           mintConfig.amounts[0]
         );
     });
@@ -290,34 +301,24 @@ describe('Core: TokenFactory', () => {
         amounts: [1],
       };
 
-      const tx = await tokenFactory.callStatic.createToken(
+      const [token, merkleMinter] = await tokenFactory.callStatic.createToken(
         dao.address,
         config,
         mintConfig
       );
 
       expect(dao.grant).to.have.been.calledWith(
-        tx[0],
-        tokenFactory.address,
-        MINT_PERMISSION_ID
-      );
-      expect(dao.revoke).to.have.been.calledWith(
-        tx[0],
-        tokenFactory.address,
-        MINT_PERMISSION_ID
-      );
-      expect(dao.grant).to.have.been.calledWith(
-        tx[0],
+        token,
         dao.address,
         MINT_PERMISSION_ID
       );
       expect(dao.grant).to.have.been.calledWith(
-        tx[0],
-        tx[1],
+        token,
+        merkleMinter,
         MINT_PERMISSION_ID
       );
       expect(dao.grant).to.have.been.calledWith(
-        tx[1],
+        merkleMinter,
         dao.address,
         MERKLE_MINT_PERMISSION_ID
       );

--- a/packages/contracts/test/merkle/merkle-minter.ts
+++ b/packages/contracts/test/merkle/merkle-minter.ts
@@ -53,7 +53,10 @@ describe('MerkleDistributor', function () {
     );
 
     const GovernanceERC20 = await ethers.getContractFactory('GovernanceERC20');
-    token = await GovernanceERC20.deploy(managingDao.address, 'GOV', 'GOV');
+    token = await GovernanceERC20.deploy(managingDao.address, 'GOV', 'GOV', {
+      receivers: [],
+      amounts: [],
+    });
 
     const MerkleDistributor = await ethers.getContractFactory(
       'MerkleDistributor'

--- a/packages/contracts/test/voting/allowlist-voting-setup.ts
+++ b/packages/contracts/test/voting/allowlist-voting-setup.ts
@@ -29,7 +29,7 @@ const MODIFY_ALLOWLIST_PERMISSION_ID = ethers.utils.id(
 const SET_CONFIGURATION_PERMISSION_ID = ethers.utils.id(
   'SET_CONFIGURATION_PERMISSION'
 );
-const UPGRADE_PERMISSION_ID = ethers.utils.id('UPGRADE_PERMISSION');
+const UPGRADE_PERMISSION_ID = ethers.utils.id('UPGRADE_PLUGIN_PERMISSION');
 const EXECUTE_PERMISSION_ID = ethers.utils.id('EXECUTE_PERMISSION');
 
 describe('AllowlistVotingSetup', function () {

--- a/packages/contracts/test/voting/erc20-voting-setup.ts
+++ b/packages/contracts/test/voting/erc20-voting-setup.ts
@@ -41,7 +41,7 @@ const merkleMintToAmountArray = [1];
 const SET_CONFIGURATION_PERMISSION_ID = ethers.utils.id(
   'SET_CONFIGURATION_PERMISSION'
 );
-const UPGRADE_PERMISSION_ID = ethers.utils.id('UPGRADE_PERMISSION');
+const UPGRADE_PERMISSION_ID = ethers.utils.id('UPGRADE_PLUGIN_PERMISSION');
 const EXECUTE_PERMISSION_ID = ethers.utils.id('EXECUTE_PERMISSION');
 const MINT_PERMISSION_ID = ethers.utils.id('MINT_PERMISSION');
 const MERKLE_MINT_PERMISSION_ID = ethers.utils.id('MERKLE_MINT_PERMISSION');


### PR DESCRIPTION
## Description

* Adds initialize mint possibility for GovernanceERC20's initialize. 
* Though, not for GovernanceWrappedERC20 as to do this, it's required for the mint addresses to have approved allowance for GovernanceWrappedERC20. This is problematic as most of the time, the addresses creator passes won't have allowance which will make the tx fail. **NOTE** that it's still possbile to mint on GovernanceWrappedERC20 without approval which would cause that amounts on the underlying token would still stay the same, but we would still mint on GovernanceWrappedERC20 ! this seems token duplication, but might be desirable. Haven't fully thought so will hear it from you first.
* Removes MerkleMinter Deployment from ERC20VotingSetup

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.