### PR TITLE
App 1232 core npm ethers doesnt export the updated active contracts list

### DIFF
--- a/.github/helpers/contracts/prepare.js
+++ b/.github/helpers/contracts/prepare.js
@@ -15,10 +15,8 @@ async function main(ref) {
     }
   }
 
-  console.log(
-    `::set-output name=environment::${isTestnet ? 'staging' : 'production'}`
-  );
-  console.log(`::set-output name=matrix::${JSON.stringify(matrix)}`);
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `environment=${isTestnet ? 'staging' : 'production'}`)
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify(matrix)}`)
 }
 
 main(process.argv[2]);

--- a/.github/helpers/subgraph/buildMatrix.js
+++ b/.github/helpers/subgraph/buildMatrix.js
@@ -16,10 +16,8 @@ async function main(ref) {
     }
   }
 
-  console.log(
-    `::set-output name=environment::${isTestnet ? 'staging' : 'production'}`
-  );
-  console.log(`::set-output name=matrix::${JSON.stringify(matrix)}`);
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `environment=${isTestnet ? 'staging' : 'production'}`)
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify(matrix)}`)
 }
 
 main(process.argv[2]);

--- a/.github/workflows/comment-triggers.yml
+++ b/.github/workflows/comment-triggers.yml
@@ -41,7 +41,7 @@ jobs:
         id: mode
         run: |
           mode=$(echo "$BODY" | sed "s|/mythx partial ||" | sed "s/ //")
-          echo "::set-output name=mode::$mode"
+          echo "mode=$mode" >> $GITHUB_OUTPUT
         env:
           BODY: ${{ github.event.comment.body }}
   mythx_partial_run:
@@ -73,7 +73,7 @@ jobs:
         id: mode
         run: |
           mode=$(echo "$BODY" | sed "s|/mythx full ||" | sed "s/ //")
-          echo "::set-output name=mode::$mode"
+          echo "mode=$mode" >> $GITHUB_OUTPUT
         env:
           BODY: ${{ github.event.comment.body }}
   mythx_full_run:
@@ -103,7 +103,7 @@ jobs:
         id: type
         run: |
           type=$(echo "$BODY" | sed "s|/release ||" | sed "s/ //")
-          echo "::set-output name=type::$type"
+          echo "type=$type" >> $GITHUB_OUTPUT
         env:
           BODY: ${{ github.event.comment.body }}
       - name: add label
@@ -129,7 +129,7 @@ jobs:
         id: type
         run: |
           type=$(echo "$BODY" | sed "s|/subgraph ||" | sed "s/ //")
-          echo "::set-output name=type::$type"
+          echo "type=$type" >> $GITHUB_OUTPUT
         env:
           BODY: ${{ github.event.comment.body }}
       - name: add label

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - name: Install yarn
         run: npm i -G yarn

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -109,7 +109,7 @@ jobs:
           git add ./packages/subgraph/	
           git commit -am "Updates files with deployed contract addresses"
           git push
-          echo "::set-output name=commitid::$(git rev-parse HEAD)"
+          echo "commitid=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
   #call-create-daos-workflow:
   #  needs: ['conclude']
   #  uses: './.github/workflows/create-dummy-dao.yml'

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -82,7 +82,7 @@ jobs:
   conclude:
     runs-on: ubuntu-latest
     outputs:
-      commitid: ${{ steps.changes.outputs.commitid }}
+      commitid: ${{ steps.commit.outputs.commitid }}
     needs: ['build-deploy']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 16
       - name: Install dependencies
         run: yarn install --pure-lockfile
@@ -50,8 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 16
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/create-dummy-dao.yml
+++ b/.github/workflows/create-dummy-dao.yml
@@ -43,8 +43,9 @@ jobs:
         with:
           ref: ${{ inputs.last_commit }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 16
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/documentation-update.yml
+++ b/.github/workflows/documentation-update.yml
@@ -13,8 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/documentation-update.yml
+++ b/.github/workflows/documentation-update.yml
@@ -34,7 +34,7 @@ jobs:
         run: cp -R packages/contracts/docs/core $GITHUB_WORKSPACE/builders-portal/docs/core
       - name: Get short commit hash
         id: hash
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/mythx-changed.yml
+++ b/.github/workflows/mythx-changed.yml
@@ -43,8 +43,9 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr_number }}/merge
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - uses: actions/setup-python@v4
       - name: Install mythx-cli

--- a/.github/workflows/mythx-changed.yml
+++ b/.github/workflows/mythx-changed.yml
@@ -67,8 +67,7 @@ jobs:
         run: |
           id=$(cat id | head -1)
           group_id=$(mythx --format=json --api-key ${{ secrets.MYTHX_API_KEY }} analysis status $id | jq -r .group_id)
-          echo "::set-output name=group_id::$group_id"
-
+          echo "group_id=$group_id" >> $GITHUB_OUTPUT
   comment:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/mythx-full.yml
+++ b/.github/workflows/mythx-full.yml
@@ -45,8 +45,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - uses: actions/setup-python@v4
       - name: Install mythx-cli

--- a/.github/workflows/mythx-full.yml
+++ b/.github/workflows/mythx-full.yml
@@ -62,8 +62,7 @@ jobs:
         run: |
           id=$(cat id | head -1)
           group_id=$(mythx --format=json --api-key ${{ secrets.MYTHX_API_KEY }} analysis status $id | jq -r .group_id)
-          echo "::set-output name=group_id::$group_id"
-      
+          echo "group_id=$group_id" >> $GITHUB_OUTPUT
   comment:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/npm-release-reusable.yml
+++ b/.github/workflows/npm-release-reusable.yml
@@ -25,15 +25,15 @@ jobs:
       - name: Is patch
         id: patch
         if: contains( github.event.pull_request.labels.*.name, 'release:patch')
-        run: echo "::set-output name=bump::patch"
+        run: echo "bump=patch" >> $GITHUB_OUTPUT
       - name: Is minor
         id: minor
         if: contains( github.event.pull_request.labels.*.name, 'release:minor')
-        run: echo "::set-output name=bump::minor"
+        run: echo "bump=minor" >> $GITHUB_OUTPUT
       - name: Is major
         id: major
         if: contains( github.event.pull_request.labels.*.name, 'release:major')
-        run: echo "::set-output name=bump::major"
+        run: echo "bump=major" >> $GITHUB_OUTPUT
   build_deploy:
     runs-on: ubuntu-latest
     needs: [prepare]

--- a/.github/workflows/npm-release-reusable.yml
+++ b/.github/workflows/npm-release-reusable.yml
@@ -50,8 +50,9 @@ jobs:
       - uses: actions/checkout@v2
         if: ${{ inputs.ref == '' }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -7,16 +7,12 @@ on:
     branches:
       - develop
       - main
-    paths:
-      - 'packages/contracts-ethers/**'
-      - '.github/workflows/npm-release.yml'
-      - '.github/workflows/npm-release-reusable.yml'
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      run: ${{ steps.checkSrc.outputs.run }}
+      run: ${{ steps.checkSrc.outputs.run }}${{ steps.checkLabel.outputs.run }}
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
@@ -28,6 +24,9 @@ jobs:
               - '.github/workflows/contracts-deploy.yml'
       - if: steps.changes.outputs.src == 'false'
         id: checkSrc
+        run: echo "run=true" >> $GITHUB_OUTPUT
+      - if: contains(toJson(github.event.pull_request.labels.*.name), 'release:') && steps.checkSrc.outputs.run != true
+        id: checkLabel
         run: echo "run=true" >> $GITHUB_OUTPUT
   npmDeploy:
     needs: ['check']

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -28,7 +28,7 @@ jobs:
               - '.github/workflows/contracts-deploy.yml'
       - if: steps.changes.outputs.src == 'false'
         id: checkSrc
-        run: echo "::set-output name=run::true"
+        run: echo "run=true" >> $GITHUB_OUTPUT
   npmDeploy:
     needs: ['check']
     if: needs.check.outputs.run != true

--- a/.github/workflows/subgraph-deploy.yaml
+++ b/.github/workflows/subgraph-deploy.yaml
@@ -38,15 +38,15 @@ jobs:
       - name: Is patch
         id: patch
         if: contains( github.event.pull_request.labels.*.name, 'subgraph:patch')
-        run: echo "::set-output name=bump::patch"
+        run: echo "bump=patch" >> $GITHUB_OUTPUT
       - name: Is minor
         id: minor
         if: contains( github.event.pull_request.labels.*.name, 'subgraph:minor')
-        run: echo "::set-output name=bump::minor"
+        run: echo "bump=minor" >> $GITHUB_OUTPUT
       - name: Is major
         id: major
         if: contains( github.event.pull_request.labels.*.name, 'subgraph:major')
-        run: echo "::set-output name=bump::major"
+        run: echo "bump=major" >> $GITHUB_OUTPUT
       - name: bump version
         working-directory: packages/subgraph
         run: |

--- a/.github/workflows/subgraph-deploy.yaml
+++ b/.github/workflows/subgraph-deploy.yaml
@@ -92,8 +92,9 @@ jobs:
         with:
           ref: ${{ github.base_ref || github.ref }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - name: Install dependencies
         run: yarn install --pure-lockfile

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -31,8 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
       - name: Install dependencies
         run: yarn install --pure-lockfile
@@ -49,11 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 14
-      - name: Install yarn
-        run: npm i -G yarn
       - name: Install dependencies
         run: yarn
       - name: Build contracts


### PR DESCRIPTION
## Description

- Removes "set-output" echos from workflows. (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Allows npm release workflow to run from all pull requests

Task: [ID]()
