### PR TITLE
Fix and clarify the execution logic of MajorityVoting

### DIFF
--- a/packages/contracts/contracts/test/MajorityVotingMock.sol
+++ b/packages/contracts/contracts/test/MajorityVotingMock.sol
@@ -7,14 +7,14 @@ import "../voting/majority/MajorityVotingBase.sol";
 contract MajorityVotingMock is MajorityVotingBase {
     function initializeMock(
         IDAO _dao,
-        uint64 _participationRequiredPct,
-        uint64 _supportRequiredPct,
+        uint64 _totalSupportThresholdPct,
+        uint64 _relativeSupportThresholdPct,
         uint64 _minDuration
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
-            _participationRequiredPct,
-            _supportRequiredPct,
+            _totalSupportThresholdPct,
+            _relativeSupportThresholdPct,
             _minDuration
         );
     }

--- a/packages/contracts/contracts/test/MajorityVotingMock.sol
+++ b/packages/contracts/contracts/test/MajorityVotingMock.sol
@@ -9,13 +9,13 @@ contract MajorityVotingMock is MajorityVotingBase {
         IDAO _dao,
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration
+        uint64 _voteDuration
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
             _totalSupportThresholdPct,
             _relativeSupportThresholdPct,
-            _minDuration
+            _voteDuration
         );
     }
 

--- a/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
+++ b/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
@@ -49,8 +49,8 @@ contract AllowlistVoting is MajorityVotingBase {
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.
-    /// @param _totalSupportThresholdPct The minimal required participation in percent.
-    /// @param _relativeSupportThresholdPct The minimal required support in percent.
+    /// @param _totalSupportThresholdPct The total support threshold in percent.
+    /// @param _relativeSupportThresholdPct The relative support threshold in percent.
     /// @param _minDuration The minimal duration of a vote.
     /// @param _allowed The allowed addresses.
     function initialize(

--- a/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
+++ b/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
@@ -49,21 +49,21 @@ contract AllowlistVoting is MajorityVotingBase {
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.
-    /// @param _participationRequiredPct The minimal required participation in percent.
-    /// @param _supportRequiredPct The minimal required support in percent.
+    /// @param _totalSupportThresholdPct The minimal required participation in percent.
+    /// @param _relativeSupportThresholdPct The minimal required support in percent.
     /// @param _minDuration The minimal duration of a vote.
     /// @param _allowed The allowed addresses.
     function initialize(
         IDAO _dao,
-        uint64 _participationRequiredPct,
-        uint64 _supportRequiredPct,
+        uint64 _totalSupportThresholdPct,
+        uint64 _relativeSupportThresholdPct,
         uint64 _minDuration,
         address[] calldata _allowed
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
-            _participationRequiredPct,
-            _supportRequiredPct,
+            _totalSupportThresholdPct,
+            _relativeSupportThresholdPct,
             _minDuration
         );
 
@@ -142,9 +142,9 @@ contract AllowlistVoting is MajorityVotingBase {
         vote_.startDate = _startDate;
         vote_.endDate = _endDate;
         vote_.snapshotBlock = snapshotBlock;
-        vote_.supportRequiredPct = supportRequiredPct;
-        vote_.participationRequiredPct = participationRequiredPct;
-        vote_.votingPower = allowedUserCount(snapshotBlock);
+        vote_.relativeSupportThresholdPct = relativeSupportThresholdPct;
+        vote_.totalSupportThresholdPct = totalSupportThresholdPct;
+        vote_.plenum = allowedUserCount(snapshotBlock);
 
         unchecked {
             for (uint256 i = 0; i < _actions.length; i++) {

--- a/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
+++ b/packages/contracts/contracts/voting/allowlist/AllowlistVoting.sol
@@ -51,20 +51,20 @@ contract AllowlistVoting is MajorityVotingBase {
     /// @param _dao The IDAO interface of the associated DAO.
     /// @param _totalSupportThresholdPct The total support threshold in percent.
     /// @param _relativeSupportThresholdPct The relative support threshold in percent.
-    /// @param _minDuration The minimal duration of a vote.
+    /// @param _voteDuration The duration of a vote.
     /// @param _allowed The allowed addresses.
     function initialize(
         IDAO _dao,
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration,
+        uint64 _voteDuration,
         address[] calldata _allowed
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
             _totalSupportThresholdPct,
             _relativeSupportThresholdPct,
-            _minDuration
+            _voteDuration
         );
 
         // add allowed users
@@ -125,14 +125,14 @@ contract AllowlistVoting is MajorityVotingBase {
         uint64 currentTimestamp = getTimestamp64();
 
         if (_startDate == 0) _startDate = currentTimestamp;
-        if (_endDate == 0) _endDate = _startDate + minDuration;
+        if (_endDate == 0) _endDate = _startDate + voteDuration;
 
-        if (_endDate - _startDate < minDuration || _startDate < currentTimestamp)
+        if (_endDate - _startDate < voteDuration || _startDate < currentTimestamp)
             revert VoteTimesInvalid({
                 current: currentTimestamp,
                 start: _startDate,
                 end: _endDate,
-                minDuration: minDuration
+                voteDuration: voteDuration
             });
 
         voteId = votesLength++;

--- a/packages/contracts/contracts/voting/allowlist/AllowlistVotingSetup.sol
+++ b/packages/contracts/contracts/voting/allowlist/AllowlistVotingSetup.sol
@@ -26,7 +26,7 @@ contract AllowlistVotingSetup is PluginSetup {
     /// @inheritdoc IPluginSetup
     function prepareInstallationDataABI() external pure returns (string memory) {
         return
-            "(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, address[] allowed)";
+            "(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 voteDuration, address[] allowed)";
     }
 
     /// @inheritdoc IPluginSetup
@@ -44,7 +44,7 @@ contract AllowlistVotingSetup is PluginSetup {
         (
             uint64 totalSupportThresholdPct,
             uint64 relativeSupportThresholdPct,
-            uint64 minDuration,
+            uint64 voteDuration,
             address[] memory allowed
         ) = abi.decode(_data, (uint64, uint64, uint64, address[]));
 
@@ -56,7 +56,7 @@ contract AllowlistVotingSetup is PluginSetup {
                 dao,
                 totalSupportThresholdPct,
                 relativeSupportThresholdPct,
-                minDuration,
+                voteDuration,
                 allowed
             )
         );

--- a/packages/contracts/contracts/voting/allowlist/AllowlistVotingSetup.sol
+++ b/packages/contracts/contracts/voting/allowlist/AllowlistVotingSetup.sol
@@ -26,7 +26,7 @@ contract AllowlistVotingSetup is PluginSetup {
     /// @inheritdoc IPluginSetup
     function prepareInstallationDataABI() external pure returns (string memory) {
         return
-            "(uint64 participationRequiredPct, uint64 supportRequiredPct, uint64 minDuration, address[] allowed)";
+            "(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, address[] allowed)";
     }
 
     /// @inheritdoc IPluginSetup
@@ -42,8 +42,8 @@ contract AllowlistVotingSetup is PluginSetup {
 
         // Decode `_data` to extract the params needed for deploying and initializing `AllowlistVoting` plugin.
         (
-            uint64 participationRequiredPct,
-            uint64 supportRequiredPct,
+            uint64 totalSupportThresholdPct,
+            uint64 relativeSupportThresholdPct,
             uint64 minDuration,
             address[] memory allowed
         ) = abi.decode(_data, (uint64, uint64, uint64, address[]));
@@ -54,8 +54,8 @@ contract AllowlistVotingSetup is PluginSetup {
             abi.encodeWithSelector(
                 AllowlistVoting.initialize.selector,
                 dao,
-                participationRequiredPct,
-                supportRequiredPct,
+                totalSupportThresholdPct,
+                relativeSupportThresholdPct,
                 minDuration,
                 allowed
             )

--- a/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
@@ -26,21 +26,21 @@ contract ERC20Voting is MajorityVotingBase {
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.
-    /// @param _participationRequiredPct The minimal required participation in percent.
-    /// @param _supportRequiredPct The minimal required support in percent.
+    /// @param _totalSupportThresholdPct The minimal required participation in percent.
+    /// @param _relativeSupportThresholdPct The minimal required support in percent.
     /// @param _minDuration The minimal duration of a vote.
     /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
     function initialize(
         IDAO _dao,
-        uint64 _participationRequiredPct,
-        uint64 _supportRequiredPct,
+        uint64 _totalSupportThresholdPct,
+        uint64 _relativeSupportThresholdPct,
         uint64 _minDuration,
         ERC20VotesUpgradeable _token
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
-            _participationRequiredPct,
-            _supportRequiredPct,
+            _totalSupportThresholdPct,
+            _relativeSupportThresholdPct,
             _minDuration
         );
 
@@ -72,8 +72,8 @@ contract ERC20Voting is MajorityVotingBase {
     ) external override returns (uint256 voteId) {
         uint64 snapshotBlock = getBlockNumber64() - 1;
 
-        uint256 votingPower = votingToken.getPastTotalSupply(snapshotBlock);
-        if (votingPower == 0) revert NoVotingPower();
+        uint256 plenum = votingToken.getPastTotalSupply(snapshotBlock);
+        if (plenum == 0) revert NoVotingPower();
 
         voteId = votesLength++;
 
@@ -95,9 +95,9 @@ contract ERC20Voting is MajorityVotingBase {
         Vote storage vote_ = votes[voteId];
         vote_.startDate = _startDate;
         vote_.endDate = _endDate;
-        vote_.supportRequiredPct = supportRequiredPct;
-        vote_.participationRequiredPct = participationRequiredPct;
-        vote_.votingPower = votingPower;
+        vote_.relativeSupportThresholdPct = relativeSupportThresholdPct;
+        vote_.totalSupportThresholdPct = totalSupportThresholdPct;
+        vote_.plenum = plenum;
         vote_.snapshotBlock = snapshotBlock;
 
         unchecked {

--- a/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
@@ -26,8 +26,8 @@ contract ERC20Voting is MajorityVotingBase {
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.
-    /// @param _totalSupportThresholdPct The minimal required participation in percent.
-    /// @param _relativeSupportThresholdPct The minimal required support in percent.
+    /// @param _totalSupportThresholdPct The total support threshold in percent.
+    /// @param _relativeSupportThresholdPct The relative support threshold in percent.
     /// @param _minDuration The minimal duration of a vote.
     /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
     function initialize(

--- a/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20Voting.sol
@@ -28,20 +28,20 @@ contract ERC20Voting is MajorityVotingBase {
     /// @param _dao The IDAO interface of the associated DAO.
     /// @param _totalSupportThresholdPct The total support threshold in percent.
     /// @param _relativeSupportThresholdPct The relative support threshold in percent.
-    /// @param _minDuration The minimal duration of a vote.
+    /// @param _voteDuration The duration of a vote.
     /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
     function initialize(
         IDAO _dao,
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration,
+        uint64 _voteDuration,
         ERC20VotesUpgradeable _token
     ) public initializer {
         __MajorityVotingBase_init(
             _dao,
             _totalSupportThresholdPct,
             _relativeSupportThresholdPct,
-            _minDuration
+            _voteDuration
         );
 
         votingToken = _token;
@@ -81,14 +81,14 @@ contract ERC20Voting is MajorityVotingBase {
         uint64 currentTimestamp = getTimestamp64();
 
         if (_startDate == 0) _startDate = currentTimestamp;
-        if (_endDate == 0) _endDate = _startDate + minDuration;
+        if (_endDate == 0) _endDate = _startDate + voteDuration;
 
-        if (_endDate - _startDate < minDuration || _startDate < currentTimestamp)
+        if (_endDate - _startDate < voteDuration || _startDate < currentTimestamp)
             revert VoteTimesInvalid({
                 current: currentTimestamp,
                 start: _startDate,
                 end: _endDate,
-                minDuration: minDuration
+                voteDuration: voteDuration
             });
 
         // Create the vote

--- a/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
+++ b/packages/contracts/contracts/voting/erc20/ERC20VotingSetup.sol
@@ -91,7 +91,7 @@ contract ERC20VotingSetup is PluginSetup {
     /// @inheritdoc IPluginSetup
     function prepareInstallationDataABI() external pure returns (string memory) {
         return
-            "(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, tuple(address addr, string name, string symbol) tokenSettings, tuple(address[] receivers, uint256[] amounts) mintSettings)";
+            "(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 voteDuration, tuple(address addr, string name, string symbol) tokenSettings, tuple(address[] receivers, uint256[] amounts) mintSettings)";
     }
 
     /// @inheritdoc IPluginSetup
@@ -110,7 +110,7 @@ contract ERC20VotingSetup is PluginSetup {
         (
             uint64 totalSupportThresholdPct,
             uint64 relativeSupportThresholdPct,
-            uint64 minDuration,
+            uint64 voteDuration,
             TokenSettings memory tokenSettings,
             // only used for GovernanceERC20(token is not passed)
             GovernanceERC20.MintSettings memory mintSettings
@@ -188,7 +188,7 @@ contract ERC20VotingSetup is PluginSetup {
                 dao,
                 totalSupportThresholdPct,
                 relativeSupportThresholdPct,
-                minDuration,
+                voteDuration,
                 token
             )
         );

--- a/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
@@ -20,12 +20,12 @@ interface IMajorityVoting {
         uint64 startDate;
         uint64 endDate;
         uint64 snapshotBlock;
-        uint64 supportRequiredPct;
-        uint64 participationRequiredPct;
+        uint64 relativeSupportThresholdPct; // previously: relativeSupportThresholdPct
+        uint64 totalSupportThresholdPct; // previously: quorum = totalSupportThresholdPct
         uint256 yes;
         uint256 no;
         uint256 abstain;
-        uint256 votingPower;
+        uint256 plenum;
         mapping(address => VoteOption) voters;
         IDAO.Action[] actions;
     }
@@ -49,22 +49,22 @@ interface IMajorityVoting {
     event VoteExecuted(uint256 indexed voteId, bytes[] execResults);
 
     /// @notice Emitted when the vote configuration is updated.
-    /// @param participationRequiredPct The required participation in percent.
-    /// @param supportRequiredPct The required support in percent.
+    /// @param totalSupportThresholdPct The required participation in percent.
+    /// @param supportThresholdPct The required support in percent.
     /// @param minDuration The minimal duration of a vote.
     event ConfigUpdated(
-        uint64 participationRequiredPct,
-        uint64 supportRequiredPct,
+        uint64 totalSupportThresholdPct,
+        uint64 supportThresholdPct,
         uint64 minDuration
     );
 
     /// @notice Sets the vote configuration.
-    /// @param _participationRequiredPct The required participation in percent.
-    /// @param _supportRequiredPct The required support in percent.
+    /// @param _totalSupportThresholdPct The required participation in percent.
+    /// @param _supportThresholdPct The required support in percent.
     /// @param _minDuration The minimal duration of a vote.
     function setConfiguration(
-        uint64 _participationRequiredPct,
-        uint64 _supportRequiredPct,
+        uint64 _totalSupportThresholdPct,
+        uint64 _supportThresholdPct,
         uint64 _minDuration
     ) external;
 
@@ -115,8 +115,8 @@ interface IMajorityVoting {
     /// @return VoteOption of the requested voter for a certain vote.
     function getVoteOption(uint256 _voteId, address _voter) external view returns (VoteOption);
 
-    /// @param participationRequiredPct The required participation in percent.
-    /// @param supportRequiredPct The required support in percent.
+    /// @param totalSupportThresholdPct The required participation in percent.
+    /// @param supportThresholdPct The required support in percent.
     /// @param minDuration The minimal duration of a vote.
 
     /// @notice Returns all information for a vote by its ID.
@@ -128,7 +128,7 @@ interface IMajorityVoting {
     /// @return snapshotBlock The block number of the snapshot taken for this vote.
     /// @return supportRequired The support required.
     /// @return participationRequired The required participation.
-    /// @return votingPower The voting power participating in the vote.
+    /// @return plenum The voting power participating in the vote.
     /// @return yes The number of `yes` votes.
     /// @return no The number of `no` votes.
     /// @return abstain The number of `abstain` votes.
@@ -144,7 +144,7 @@ interface IMajorityVoting {
             uint64 snapshotBlock,
             uint64 supportRequired,
             uint64 participationRequired,
-            uint256 votingPower,
+            uint256 plenum,
             uint256 yes,
             uint256 no,
             uint256 abstain,

--- a/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
@@ -6,7 +6,9 @@ import "../../core/IDAO.sol";
 
 /// @title IMajorityVoting
 /// @author Aragon Association - 2022
-/// @notice The interface for majority voting contracts.
+/// @notice The interface for majority voting contracts. We use the following definitions:
+///     Relative support: `N_yes / (N_yes + N_no)`
+///     Total support   : `N_yes/ N_total`
 interface IMajorityVoting {
     enum VoteOption {
         None,
@@ -20,7 +22,7 @@ interface IMajorityVoting {
         uint64 startDate;
         uint64 endDate;
         uint64 snapshotBlock;
-        uint64 relativeSupportThresholdPct; // previously: relativeSupportThresholdPct
+        uint64 relativeSupportThresholdPct; // `N_yes/ N_total * 100`
         uint64 totalSupportThresholdPct; // previously: quorum = totalSupportThresholdPct
         uint256 yes;
         uint256 no;
@@ -49,22 +51,22 @@ interface IMajorityVoting {
     event VoteExecuted(uint256 indexed voteId, bytes[] execResults);
 
     /// @notice Emitted when the vote configuration is updated.
-    /// @param totalSupportThresholdPct The required participation in percent.
-    /// @param supportThresholdPct The required support in percent.
+    /// @param relativeSupportThresholdPct The relative support threshold in percent.
+    /// @param totalSupportThresholdPct The total support threshold in percent.
     /// @param minDuration The minimal duration of a vote.
     event ConfigUpdated(
         uint64 totalSupportThresholdPct,
-        uint64 supportThresholdPct,
+        uint64 relativeSupportThresholdPct,
         uint64 minDuration
     );
 
     /// @notice Sets the vote configuration.
-    /// @param _totalSupportThresholdPct The required participation in percent.
-    /// @param _supportThresholdPct The required support in percent.
+    /// @param _totalSupportThresholdPct The total support threshold in percent.
+    /// @param _relativeSupportThresholdPct The relative support threshold in percent.
     /// @param _minDuration The minimal duration of a vote.
     function setConfiguration(
+        uint64 _relativeSupportThresholdPct,
         uint64 _totalSupportThresholdPct,
-        uint64 _supportThresholdPct,
         uint64 _minDuration
     ) external;
 
@@ -115,10 +117,6 @@ interface IMajorityVoting {
     /// @return VoteOption of the requested voter for a certain vote.
     function getVoteOption(uint256 _voteId, address _voter) external view returns (VoteOption);
 
-    /// @param totalSupportThresholdPct The required participation in percent.
-    /// @param supportThresholdPct The required support in percent.
-    /// @param minDuration The minimal duration of a vote.
-
     /// @notice Returns all information for a vote by its ID.
     /// @param _voteId The ID of the vote.
     /// @return open Wheter the vote is open or not.
@@ -126,8 +124,8 @@ interface IMajorityVoting {
     /// @return startDate The start date of the vote.
     /// @return endDate The end date of the vote.
     /// @return snapshotBlock The block number of the snapshot taken for this vote.
-    /// @return supportRequired The support required.
-    /// @return participationRequired The required participation.
+    /// @return relativeSupportThresholdPct The relative support threshold in percent.
+    /// @return totalSupportThresholdPct The total support threshold in percent.
     /// @return plenum The voting power participating in the vote.
     /// @return yes The number of `yes` votes.
     /// @return no The number of `no` votes.
@@ -142,8 +140,8 @@ interface IMajorityVoting {
             uint64 startDate,
             uint64 endDate,
             uint64 snapshotBlock,
-            uint64 supportRequired,
-            uint64 participationRequired,
+            uint64 relativeSupportThresholdPct,
+            uint64 totalSupportThresholdPct,
             uint256 plenum,
             uint256 yes,
             uint256 no,

--- a/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
@@ -53,28 +53,28 @@ interface IMajorityVoting {
     /// @notice Emitted when the vote configuration is updated.
     /// @param relativeSupportThresholdPct The relative support threshold in percent.
     /// @param totalSupportThresholdPct The total support threshold in percent.
-    /// @param minDuration The minimal duration of a vote.
+    /// @param voteDuration The duration of a vote.
     event ConfigUpdated(
         uint64 totalSupportThresholdPct,
         uint64 relativeSupportThresholdPct,
-        uint64 minDuration
+        uint64 voteDuration
     );
 
     /// @notice Sets the vote configuration.
     /// @param _totalSupportThresholdPct The total support threshold in percent.
     /// @param _relativeSupportThresholdPct The relative support threshold in percent.
-    /// @param _minDuration The minimal duration of a vote.
+    /// @param _voteDuration The duration of a vote.
     function setConfiguration(
         uint64 _relativeSupportThresholdPct,
         uint64 _totalSupportThresholdPct,
-        uint64 _minDuration
+        uint64 _voteDuration
     ) external;
 
     /// @notice Creates a new vote.
     /// @param _proposalMetadata The IPFS hash pointing to the proposal metadata.
     /// @param _actions The actions that will be executed after vote passes.
     /// @param _startDate The start date of the vote. If 0, uses current timestamp.
-    /// @param _endDate The end date of the vote. If 0, uses `_start` + `minDuration`.
+    /// @param _endDate The end date of the vote. If 0, uses `_start` + `voteDuration`.
     /// @param _executeIfDecided An option to enable automatic execution on the last required vote.
     /// @param _choice The vote choice to cast on creation.
     /// @return voteId The ID of the vote.

--- a/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
+++ b/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
@@ -14,10 +14,9 @@ import {IDAO} from "../../core/IDAO.sol";
 /// @title MajorityVotingBase
 /// @author Aragon Association - 2022
 /// @notice The abstract implementation of majority voting components.
-/// TODO    We use the following definitions
-/// TODO    $relative support = \frac{N_{yes}}{N_{yes}+N_{no}}$
-/// TODO    $total support = \frac{N_{yes}}{N_{total}}$
-/// TODO    $participation = \frac{N_{yes}+N_{no}+N_{abstain}}{N_{total}}$
+/// We use the following definitions
+/// $relative support = \frac{N_{yes}}{N_{yes}+N_{no}}$
+/// $total support = \frac{N_{yes}}{N_{total}}$
 /// @dev This component implements the `IMajorityVoting` interface.
 abstract contract MajorityVotingBase is
     IMajorityVoting,

--- a/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
+++ b/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
@@ -39,7 +39,7 @@ abstract contract MajorityVotingBase is
 
     uint64 public relativeSupportThresholdPct;
     uint64 public totalSupportThresholdPct;
-    uint64 public minDuration;
+    uint64 public voteDuration;
     uint256 public votesLength;
 
     /// @notice Thrown if a specified percentage value exceeds the limit (100% = 10^18).
@@ -51,8 +51,8 @@ abstract contract MajorityVotingBase is
     /// @param current The maximal value.
     /// @param start The start date of the vote as a unix timestamp.
     /// @param end The end date of the vote as a unix timestamp.
-    /// @param minDuration The minimal duration of the vote in seconds.
-    error VoteTimesInvalid(uint64 current, uint64 start, uint64 end, uint64 minDuration);
+    /// @param voteDuration The duration of the vote in seconds.
+    error VoteTimesInvalid(uint64 current, uint64 start, uint64 end, uint64 voteDuration);
 
     /// @notice Thrown if the selected vote duration is zero
     error VoteDurationZero(); ///TODO  remove
@@ -73,22 +73,22 @@ abstract contract MajorityVotingBase is
     /// @param _dao The IDAO interface of the associated DAO.
     /// @param _totalSupportThresholdPct The total support threshold in percent.
     /// @param _relativeSupportThresholdPct The relative support threshold in percent.
-    /// @param _minDuration The minimal duration of a vote
+    /// @param _voteDuration The duration of a vote
     function __MajorityVotingBase_init(
         IDAO _dao,
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration
+        uint64 _voteDuration
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
 
         _validateAndSetSettings(
             _totalSupportThresholdPct,
             _relativeSupportThresholdPct,
-            _minDuration
+            _voteDuration
         );
 
-        emit ConfigUpdated(_totalSupportThresholdPct, _relativeSupportThresholdPct, _minDuration);
+        emit ConfigUpdated(_totalSupportThresholdPct, _relativeSupportThresholdPct, _voteDuration);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -108,15 +108,15 @@ abstract contract MajorityVotingBase is
     function setConfiguration(
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration
+        uint64 _voteDuration
     ) external auth(SET_CONFIGURATION_PERMISSION_ID) {
         _validateAndSetSettings(
             _totalSupportThresholdPct,
             _relativeSupportThresholdPct,
-            _minDuration
+            _voteDuration
         );
 
-        emit ConfigUpdated(_totalSupportThresholdPct, _relativeSupportThresholdPct, _minDuration);
+        emit ConfigUpdated(_totalSupportThresholdPct, _relativeSupportThresholdPct, _voteDuration);
     }
 
     /// @inheritdoc IMajorityVoting
@@ -298,7 +298,7 @@ abstract contract MajorityVotingBase is
     function _validateAndSetSettings(
         uint64 _totalSupportThresholdPct,
         uint64 _relativeSupportThresholdPct,
-        uint64 _minDuration
+        uint64 _voteDuration
     ) internal virtual {
         if (_relativeSupportThresholdPct > PCT_BASE) {
             revert PercentageExceeds100({limit: PCT_BASE, actual: _relativeSupportThresholdPct});
@@ -308,13 +308,13 @@ abstract contract MajorityVotingBase is
             revert PercentageExceeds100({limit: PCT_BASE, actual: _totalSupportThresholdPct});
         }
 
-        if (_minDuration == 0) {
+        if (_voteDuration == 0) {
             revert VoteDurationZero();
         }
 
         totalSupportThresholdPct = _totalSupportThresholdPct;
         relativeSupportThresholdPct = _relativeSupportThresholdPct;
-        minDuration = _minDuration;
+        voteDuration = _voteDuration;
     }
 
     /// @notice This empty reserved space is put in place to allow future versions to add new variables without shifting down storage in the inheritance chain (see [OpenZepplins guide about storage gaps](https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).

--- a/packages/contracts/test/core/dao.ts
+++ b/packages/contracts/test/core/dao.ts
@@ -1,8 +1,9 @@
 import {expect} from 'chai';
-import hre, {ethers} from 'hardhat';
+import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
 import {DAO, GovernanceERC20} from '../../typechain';
+import {findEvent, DAO_EVENTS} from '../../utils/event';
 import {ERRORS, customError} from '../test-utils/custom-error-helper';
 import {getInterfaceID} from '../test-utils/interfaces';
 import {IERC1271__factory} from '../../typechain/factories/IERC1271__factory';
@@ -204,17 +205,15 @@ describe('DAO', function () {
       let tx = await dao.execute(0, dummyActions);
       let rc = await tx.wait();
 
-      const {actor, callId, actions, execResults} = dao.interface.parseLog(
-        rc.logs[0]
-      ).args;
+      const event = await findEvent(tx, DAO_EVENTS.EXECUTED);
 
-      expect(actor).to.equal(ownerAddress);
-      expect(callId).to.equal(0);
-      expect(actions.length).to.equal(1);
-      expect(actions[0].to).to.equal(dummyActions[0].to);
-      expect(actions[0].value).to.equal(dummyActions[0].value);
-      expect(actions[0].data).to.equal(dummyActions[0].data);
-      expect(execResults).to.deep.equal(expectedDummyResults);
+      expect(event.args.actor).to.equal(ownerAddress);
+      expect(event.args.callId).to.equal(0);
+      expect(event.args.actions.length).to.equal(1);
+      expect(event.args.actions[0].to).to.equal(dummyActions[0].to);
+      expect(event.args.actions[0].value).to.equal(dummyActions[0].value);
+      expect(event.args.actions[0].data).to.equal(dummyActions[0].data);
+      expect(event.args.execResults).to.deep.equal(expectedDummyResults);
     });
   });
 

--- a/packages/contracts/test/test-utils/voting.ts
+++ b/packages/contracts/test/test-utils/voting.ts
@@ -10,10 +10,3 @@ export enum VoteOption {
 const toBn = ethers.BigNumber.from;
 const bigExp = (x: number, y: number) => toBn(x).mul(toBn(10).pow(toBn(y)));
 export const pct16 = (x: number) => bigExp(x, 16);
-
-export const VOTING_EVENTS = {
-  CONFIG_UPDATED: 'ConfigUpdated',
-  VOTE_STARTED: 'VoteCreated',
-  VOTE_CAST: 'VoteCast',
-  VOTE_EXECUTED: 'VoteExecuted',
-};

--- a/packages/contracts/test/test-utils/voting.ts
+++ b/packages/contracts/test/test-utils/voting.ts
@@ -10,3 +10,8 @@ export enum VoteOption {
 const toBn = ethers.BigNumber.from;
 const bigExp = (x: number, y: number) => toBn(x).mul(toBn(10).pow(toBn(y)));
 export const pct16 = (x: number) => bigExp(x, 16);
+
+export async function advanceTime(time: number) {
+  await ethers.provider.send('evm_increaseTime', [time]);
+  await ethers.provider.send('evm_mine', []);
+}

--- a/packages/contracts/test/voting/allowlist-voting-setup.ts
+++ b/packages/contracts/test/voting/allowlist-voting-setup.ts
@@ -73,7 +73,7 @@ describe('AllowlistVotingSetup', function () {
     it('correctly returns prepare installation data abi', async () => {
       // Human-Readable Abi of data param of `prepareInstallation`.
       const dataHRABI =
-        '(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, address[] allowed)';
+        '(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 voteDuration, address[] allowed)';
 
       expect(await allowlistVotingSetup.prepareInstallationDataABI()).to.be.eq(
         dataHRABI
@@ -154,7 +154,7 @@ describe('AllowlistVotingSetup', function () {
       const daoAddress = targetDao.address;
       const totalSupportThresholdPct = 1;
       const relativeSupportThresholdPct = 2;
-      const minDuration = 3;
+      const voteDuration = 3;
       const allowed = [ownerAddress];
 
       const data = abiCoder.encode(
@@ -162,7 +162,7 @@ describe('AllowlistVotingSetup', function () {
         [
           totalSupportThresholdPct,
           relativeSupportThresholdPct,
-          minDuration,
+          voteDuration,
           allowed,
         ]
       );
@@ -188,8 +188,8 @@ describe('AllowlistVotingSetup', function () {
       expect(
         await allowlistVotingContract.relativeSupportThresholdPct()
       ).to.be.equal(relativeSupportThresholdPct);
-      expect(await allowlistVotingContract.minDuration()).to.be.equal(
-        minDuration
+      expect(await allowlistVotingContract.voteDuration()).to.be.equal(
+        voteDuration
       );
 
       await ethers.provider.send('evm_mine', []);

--- a/packages/contracts/test/voting/allowlist-voting-setup.ts
+++ b/packages/contracts/test/voting/allowlist-voting-setup.ts
@@ -73,7 +73,7 @@ describe('AllowlistVotingSetup', function () {
     it('correctly returns prepare installation data abi', async () => {
       // Human-Readable Abi of data param of `prepareInstallation`.
       const dataHRABI =
-        '(uint64 participationRequiredPct, uint64 supportRequiredPct, uint64 minDuration, address[] allowed)';
+        '(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, address[] allowed)';
 
       expect(await allowlistVotingSetup.prepareInstallationDataABI()).to.be.eq(
         dataHRABI
@@ -152,14 +152,19 @@ describe('AllowlistVotingSetup', function () {
 
     it('correctly sets up the plugin', async () => {
       const daoAddress = targetDao.address;
-      const participationRequiredPct = 1;
-      const supportRequiredPct = 2;
+      const totalSupportThresholdPct = 1;
+      const relativeSupportThresholdPct = 2;
       const minDuration = 3;
       const allowed = [ownerAddress];
 
       const data = abiCoder.encode(
         ['uint64', 'uint64', 'uint64', 'address[]'],
-        [participationRequiredPct, supportRequiredPct, minDuration, allowed]
+        [
+          totalSupportThresholdPct,
+          relativeSupportThresholdPct,
+          minDuration,
+          allowed,
+        ]
       );
 
       const nonce = await ethers.provider.getTransactionCount(
@@ -178,11 +183,11 @@ describe('AllowlistVotingSetup', function () {
 
       expect(await allowlistVotingContract.getDAO()).to.be.equal(daoAddress);
       expect(
-        await allowlistVotingContract.participationRequiredPct()
-      ).to.be.equal(participationRequiredPct);
-      expect(await allowlistVotingContract.supportRequiredPct()).to.be.equal(
-        supportRequiredPct
-      );
+        await allowlistVotingContract.totalSupportThresholdPct()
+      ).to.be.equal(totalSupportThresholdPct);
+      expect(
+        await allowlistVotingContract.relativeSupportThresholdPct()
+      ).to.be.equal(relativeSupportThresholdPct);
       expect(await allowlistVotingContract.minDuration()).to.be.equal(
         minDuration
       );

--- a/packages/contracts/test/voting/allowlist-voting.ts
+++ b/packages/contracts/test/voting/allowlist-voting.ts
@@ -448,16 +448,16 @@ describe('AllowlistVoting', function () {
 
       it('does not execute if support is high enough but participation and approval (absolute support) are too low', async () => {
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 10% !  0  | 10% | 100%
-        //     !  𐄂  |  𐄂  |  ✓
+        // dur | tot | rel
+        //  0  | 10% | 100%
+        //  𐄂  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // Reason: approval and participation are too low
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 10% ! 510 | 10% | 100%
-        //     !  ✓  |  𐄂  |  ✓
+        // dur | tot | rel
+        // 510 | 10% | 100%
+        //  ✓  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // vote end does not help
       });
 
@@ -465,16 +465,16 @@ describe('AllowlistVoting', function () {
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[1]).vote(id, VoteOption.No, false);
         await voting.connect(signers[2]).vote(id, VoteOption.No, false);
-        // par ! dur | tot | rel
-        // 30% !  0  | 30% | 33%
-        //     !  𐄂  |  ✓  |  𐄂
+        // dur | tot | rel
+        //  0  | 30% | 33%
+        //  𐄂  |  ✓  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false); // approval too low, duration and support criterium are not met
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 30% ! 510 | 30% | 33%
-        //     !  ✓  |  ✓  |  𐄂
+        // dur | tot | rel
+        // 510 | 30% | 33%
+        //  ✓  |  ✓  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false); // vote end does not help
       });
 
@@ -482,16 +482,16 @@ describe('AllowlistVoting', function () {
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[1]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[2]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 30% !  0  | 30% | 100%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 30% | 100%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // Reason: duration criterium is not met
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 30% ! 510 | 30% | 100%
-        //     !  ✓  |  ✓  |  ✓
+        // dur | tot | rel
+        // 510 | 30% | 100%
+        //  ✓  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // all criteria are met
       });
 
@@ -501,24 +501,24 @@ describe('AllowlistVoting', function () {
         await voting.connect(signers[2]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[3]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[4]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 50% !  0  | 50% | 100%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 50% | 100%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // Reason: app > supReq == false
 
         await voting.connect(signers[5]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 60% !  0  | 60% | 100%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 60% | 100%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // Correct because more voting doesn't change the outcome
 
         await voting.connect(signers[6]).vote(id, VoteOption.No, false);
         await voting.connect(signers[7]).vote(id, VoteOption.No, false);
         await voting.connect(signers[8]).vote(id, VoteOption.No, false);
         await voting.connect(signers[9]).vote(id, VoteOption.No, false);
-        // par ! dur | tot | rel
-        //100% !  0  | 60% | 60%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 60% | 60%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // The outcome did not change
       });
     });
@@ -559,21 +559,21 @@ describe('AllowlistVoting', function () {
 
       it('early execution is possible', async () => {
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 20% !  0  | 20% | 100%
-        //     !  𐄂  |  𐄂  |  ✓
+        // dur | tot | rel
+        //  0  | 20% | 100%
+        //  𐄂  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false);
 
         await voting.connect(signers[1]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 40% !  0  | 40% | 100%
-        //     !  𐄂  |  𐄂  |  𐄂
+        // dur | tot | rel
+        //  0  | 40% | 100%
+        //  𐄂  |  𐄂  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false);
 
         await voting.connect(signers[2]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 60% !  0  | 60% | 100%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 60% | 100%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true);
       });
 
@@ -581,17 +581,17 @@ describe('AllowlistVoting', function () {
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[1]).vote(id, VoteOption.Yes, false);
         await voting.connect(signers[2]).vote(id, VoteOption.No, false);
-        // par ! dur | tot | rel
-        // 60% !  0  | 40% | 67%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 40% | 67%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(false);
 
         // Wait until the voting period is over.
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 60% ! 510 | 40% | 67%
-        //     !  ✓  |  ✓  |  ✓
+        // dur | tot | rel
+        // 510 | 40% | 67%
+        //  ✓  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(false);
       });
     });

--- a/packages/contracts/test/voting/allowlist-voting.ts
+++ b/packages/contracts/test/voting/allowlist-voting.ts
@@ -325,7 +325,7 @@ describe('AllowlistVoting', function () {
       expect((await voting.getVote(id)).abstain).to.equal(1);
     });
 
-    it('becomes executable if enough yes is given from voting power', async () => {
+    it('can execute early if total support is large enough', async () => {
       // Since voting power is set to 29%, and
       // allowlist is 10 addresses, voting yes
       // from 3 addresses should be enough to
@@ -335,13 +335,13 @@ describe('AllowlistVoting', function () {
 
       // // only 2 voted, not enough for 30%
       expect(await voting.canExecute(id)).to.equal(false);
-      // // 3rd votes, enough.
+      // // 3rd vote, enough.
       await voting.connect(signers[2]).vote(id, VoteOption.Yes, false);
 
       expect(await voting.canExecute(id)).to.equal(true);
     });
 
-    it('becomes executable if enough yes is given depending on yes + no total', async () => {
+    it('can execute normally if total support is large enough', async () => {
       // 2 supports
       await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
       await voting.connect(signers[1]).vote(id, VoteOption.Yes, false);
@@ -404,7 +404,7 @@ describe('AllowlistVoting', function () {
       );
     });
 
-    it('reverts if vote is executed while enough yes is not given ', async () => {
+    it('reverts if vote is not decided yet', async () => {
       await expect(voting.execute(id)).to.be.revertedWith(
         customError('VoteExecutionForbidden', id)
       );

--- a/packages/contracts/test/voting/allowlist-voting.ts
+++ b/packages/contracts/test/voting/allowlist-voting.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
-import {Bytes} from 'ethers';
 
 import {AllowlistVoting, DAO} from '../../typechain';
-import {VoteOption, VOTING_EVENTS, pct16} from '../test-utils/voting';
+import {findEvent, DAO_EVENTS, VOTING_EVENTS} from '../../utils/event';
+import {VoteOption, pct16} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 describe('AllowlistVoting', function () {
@@ -359,17 +359,15 @@ describe('AllowlistVoting', function () {
 
       // check for the `Executed` event in the DAO
       {
-        let {actor, callId, actions, execResults} = dao.interface.parseLog(
-          rc.logs[1]
-        ).args;
+        const event = await findEvent(tx, DAO_EVENTS.EXECUTED);
 
-        expect(actor).to.equal(voting.address);
-        expect(callId).to.equal(id);
-        expect(actions.length).to.equal(1);
-        expect(actions[0].to).to.equal(dummyActions[0].to);
-        expect(actions[0].value).to.equal(dummyActions[0].value);
-        expect(actions[0].data).to.equal(dummyActions[0].data);
-        expect(execResults).to.deep.equal([]);
+        expect(event.args.actor).to.equal(voting.address);
+        expect(event.args.callId).to.equal(id);
+        expect(event.args.actions.length).to.equal(1);
+        expect(event.args.actions[0].to).to.equal(dummyActions[0].to);
+        expect(event.args.actions[0].value).to.equal(dummyActions[0].value);
+        expect(event.args.actions[0].data).to.equal(dummyActions[0].data);
+        expect(event.args.execResults).to.deep.equal(['0x']);
 
         const vote = await voting.getVote(id);
 
@@ -378,11 +376,9 @@ describe('AllowlistVoting', function () {
 
       // check for the `VoteExecuted` event in the voting contract
       {
-        const {voteId, execResults} = voting.interface.parseLog(
-          rc.logs[2]
-        ).args;
-        expect(voteId).to.equal(id);
-        expect(execResults).to.deep.equal([]);
+        const event = await findEvent(tx, VOTING_EVENTS.VOTE_EXECUTED);
+        expect(event.args.voteId).to.equal(id);
+        expect(event.args.execResults).to.deep.equal(['0x']);
       }
 
       // calling execute again should fail

--- a/packages/contracts/test/voting/allowlist-voting.ts
+++ b/packages/contracts/test/voting/allowlist-voting.ts
@@ -72,14 +72,14 @@ describe('AllowlistVoting', function () {
   function initializeVoting(
     totalSupportThresholdPct: any,
     relativeSupportThresholdPct: any,
-    minDuration: any,
+    voteDuration: any,
     allowed: Array<string>
   ) {
     return voting.initialize(
       dao.address,
       totalSupportThresholdPct,
       relativeSupportThresholdPct,
-      minDuration,
+      voteDuration,
       allowed
     );
   }
@@ -140,7 +140,7 @@ describe('AllowlistVoting', function () {
   });
 
   describe('StartVote', async () => {
-    let minDuration = 3;
+    let voteDuration = 3;
 
     beforeEach(async () => {
       await initializeVoting(1, 2, 3, [ownerAddress]);
@@ -156,11 +156,11 @@ describe('AllowlistVoting', function () {
       );
     });
 
-    it('reverts if vote duration is less than minDuration', async () => {
+    it('reverts if vote duration is less than voteDuration', async () => {
       const block = await ethers.provider.getBlock('latest');
       const current = block.timestamp;
       const startDate = block.timestamp;
-      const endDate = startDate + (minDuration - 1);
+      const endDate = startDate + (voteDuration - 1);
       await expect(
         voting.createVote(
           dummyMetadata,
@@ -176,7 +176,7 @@ describe('AllowlistVoting', function () {
           current + 1, // TODO hacky
           startDate,
           endDate,
-          minDuration
+          voteDuration
         )
       );
     });
@@ -208,7 +208,7 @@ describe('AllowlistVoting', function () {
       expect(vote.yes).to.equal(0);
       expect(vote.no).to.equal(0);
 
-      expect(vote.startDate.add(minDuration)).to.equal(vote.endDate);
+      expect(vote.startDate.add(voteDuration)).to.equal(vote.endDate);
 
       expect(await voting.canVote(id, ownerAddress)).to.equal(true);
       expect(await voting.canVote(id, user1)).to.equal(false);
@@ -252,7 +252,7 @@ describe('AllowlistVoting', function () {
   });
 
   describe('Vote + Execute:', async () => {
-    let minDuration = 500;
+    let voteDuration = 500;
     let relativeSupportThresholdPct = pct16(29);
     let totalSupportThresholdPct = pct16(19);
     const id = 0; // voteId
@@ -270,7 +270,7 @@ describe('AllowlistVoting', function () {
       await initializeVoting(
         totalSupportThresholdPct,
         relativeSupportThresholdPct,
-        minDuration,
+        voteDuration,
         addresses
       );
 
@@ -357,7 +357,7 @@ describe('AllowlistVoting', function () {
       expect(await voting.canExecute(id)).to.equal(false);
 
       // closes the vote.
-      await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
+      await ethers.provider.send('evm_increaseTime', [voteDuration + 10]);
       await ethers.provider.send('evm_mine', []);
 
       // 2 voted yes, 2 voted no. 2 voted abstain.
@@ -415,7 +415,7 @@ describe('AllowlistVoting', function () {
     const id = 0; // voteId
 
     describe('A simple majority vote with >50% relative support and >25% total support required', async () => {
-      let minDuration = 500;
+      let voteDuration = 500;
       let relativeSupportThresholdPct = pct16(50);
       let totalSupportThresholdPct = pct16(25);
 
@@ -432,7 +432,7 @@ describe('AllowlistVoting', function () {
         await initializeVoting(
           totalSupportThresholdPct,
           relativeSupportThresholdPct,
-          minDuration,
+          voteDuration,
           addresses
         );
 
@@ -453,7 +453,7 @@ describe('AllowlistVoting', function () {
         //  𐄂  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // total support (10%) > relative support threshold (50%) == false
 
-        await advanceTime(minDuration + 10);
+        await advanceTime(voteDuration + 10);
         // dur | tot | rel
         // 510 | 10% | 100%
         //  ✓  |  𐄂  |  ✓
@@ -469,7 +469,7 @@ describe('AllowlistVoting', function () {
         //  𐄂  |  ✓  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false); // total support (30%) > relative support threshold (50%) == false
 
-        await advanceTime(minDuration + 10);
+        await advanceTime(voteDuration + 10);
         // dur | tot | rel
         // 510 | 30% | 33%
         //  ✓  |  ✓  |  𐄂
@@ -485,7 +485,7 @@ describe('AllowlistVoting', function () {
         //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // vote duration is not over
 
-        await advanceTime(minDuration + 10);
+        await advanceTime(voteDuration + 10);
         // dur | tot | rel
         // 510 | 30% | 100%
         //  ✓  |  ✓  |  ✓
@@ -521,7 +521,7 @@ describe('AllowlistVoting', function () {
     });
 
     describe('A 3/5 multi-sig', async () => {
-      let minDuration = 500;
+      let voteDuration = 500;
 
       // pay attention to decrement the required percentage value by one because the compared value has to be larger
       let relativeSupportThresholdPct = pct16(60).sub(ethers.BigNumber.from(1));
@@ -540,7 +540,7 @@ describe('AllowlistVoting', function () {
         await initializeVoting(
           totalSupportThresholdPct,
           relativeSupportThresholdPct,
-          minDuration,
+          voteDuration,
           addresses
         );
 
@@ -584,7 +584,7 @@ describe('AllowlistVoting', function () {
         expect(await voting.canExecute(id)).to.equal(false); // total support (40%) > relative support threshold (59%) == false
 
         // Wait until the voting period is over.
-        await advanceTime(minDuration + 10);
+        await advanceTime(voteDuration + 10);
         // dur | tot | rel
         // 510 | 40% | 67%
         //  ✓  |  𐄂  |  ✓

--- a/packages/contracts/test/voting/erc20-voting-setup.ts
+++ b/packages/contracts/test/voting/erc20-voting-setup.ts
@@ -36,7 +36,7 @@ const MINIMUM_DATA = abiCoder.encode(prepareInstallDataTypes, [
 
 const totalSupportThresholdPct = 1;
 const relativeSupportThresholdPct = 2;
-const minDuration = 3;
+const voteDuration = 3;
 const tokenName = 'name';
 const tokenSymbol = 'symbol';
 const merkleMintToAddressArray = [ethers.Wallet.createRandom().address];
@@ -80,7 +80,7 @@ describe('ERC20VotingSetup', function () {
 
     const iface = new ethers.utils.Interface([
       'function getVotingToken() returns (address)',
-      'function initialize(address _dao, uint64 _totalSupportThresholdPct, uint64 _relativeSupportThresholdPct, uint64 _minDuration, address _token)',
+      'function initialize(address _dao, uint64 _totalSupportThresholdPct, uint64 _relativeSupportThresholdPct, uint64 _voteDuration, address _token)',
     ]);
 
     expect(
@@ -92,7 +92,7 @@ describe('ERC20VotingSetup', function () {
     it('correctly returns prepare installation data abi', async () => {
       // Human-Readable Abi of data param of `prepareInstallation`.
       const dataHRABI =
-        '(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 minDuration, tuple(address addr, string name, string symbol) tokenSettings, tuple(address[] receivers, uint256[] amounts) mintSettings)';
+        '(uint64 totalSupportThresholdPct, uint64 relativeSupportThresholdPct, uint64 voteDuration, tuple(address addr, string name, string symbol) tokenSettings, tuple(address[] receivers, uint256[] amounts) mintSettings)';
 
       expect(await erc20VotingSetup.prepareInstallationDataABI()).to.be.eq(
         dataHRABI
@@ -378,7 +378,7 @@ describe('ERC20VotingSetup', function () {
       const data = abiCoder.encode(prepareInstallDataTypes, [
         totalSupportThresholdPct,
         relativeSupportThresholdPct,
-        minDuration,
+        voteDuration,
         [AddressZero, tokenName, tokenSymbol],
         [merkleMintToAddressArray, merkleMintToAmountArray],
       ]);
@@ -410,7 +410,9 @@ describe('ERC20VotingSetup', function () {
       expect(
         await erc20VotingContract.relativeSupportThresholdPct()
       ).to.be.equal(relativeSupportThresholdPct);
-      expect(await erc20VotingContract.minDuration()).to.be.equal(minDuration);
+      expect(await erc20VotingContract.voteDuration()).to.be.equal(
+        voteDuration
+      );
       expect(await erc20VotingContract.getVotingToken()).to.be.equal(
         anticipatedTokenAddress
       );

--- a/packages/contracts/test/voting/erc20-voting.ts
+++ b/packages/contracts/test/voting/erc20-voting.ts
@@ -302,7 +302,7 @@ describe('ERC20Voting', function () {
       expect((await voting.getVote(id)).abstain).to.equal(1);
     });
 
-    it('can execute early if support is large enough', async () => {
+    it('can execute early if total support is large enough', async () => {
       // vote with 50 yes votes, which is NOT enough to make vote executable as relative support
       // must be larger than relativeSupportThresholdPct = 50
       await erc20VoteMock.mock.getPastVotes.returns(50);
@@ -318,7 +318,7 @@ describe('ERC20Voting', function () {
       expect(await voting.canExecute(id)).to.equal(true);
     });
 
-    it('can execute if enough yes votes are given depending on yes+no+abstain total', async () => {
+    it('can execute normally if total support is large enough', async () => {
       // vote with 50 yes votes
       await erc20VoteMock.mock.getPastVotes.returns(50);
       await voting.vote(id, VoteOption.Yes, false);
@@ -338,7 +338,7 @@ describe('ERC20Voting', function () {
       expect(await voting.canExecute(id)).to.equal(true);
     });
 
-    it("cannot execute if enough yes isn't given depending on yes + no + abstain total", async () => {
+    it('cannot execute normally if total support is too low', async () => {
       // vote with 10 yes votes
       await erc20VoteMock.mock.getPastVotes.returns(10);
       await voting.vote(id, VoteOption.Yes, false);
@@ -354,7 +354,7 @@ describe('ERC20Voting', function () {
       // closes the vote
       await advanceTime(voteDuration + 10);
 
-      //The vote is not executable because the total support with 20% is still too low, despite a support of 66% and the voting period being over
+      //The vote is not executable because the total support with 20% is still too low, despite a relative support of 66% and the voting period being over
       expect(await voting.canExecute(id)).to.equal(false);
     });
 
@@ -397,7 +397,7 @@ describe('ERC20Voting', function () {
       );
     });
 
-    it('reverts if vote is executed while enough yes is not given ', async () => {
+    it('reverts if vote is not decided yet', async () => {
       await expect(voting.execute(id)).to.be.revertedWith(
         customError('VoteExecutionForbidden', id)
       );

--- a/packages/contracts/test/voting/erc20-voting.ts
+++ b/packages/contracts/test/voting/erc20-voting.ts
@@ -11,7 +11,7 @@ import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 const {deployMockContract} = waffle;
 
-describe.only('ERC20Voting', function () {
+describe('ERC20Voting', function () {
   let signers: SignerWithAddress[];
   let voting: any;
   let dao: DAO;
@@ -437,16 +437,16 @@ describe.only('ERC20Voting', function () {
 
       it('does not execute if support is high enough but participation and approval (absolute support) are too low', async () => {
         await erc20VoteMock.mock.getPastVotes.returns(10);
-        // par ! dur | tot | rel
-        // 10% !  0  | 10% | 100%
-        //     !  𐄂  |  𐄂  |  ✓
+        // dur | tot | rel
+        //  0  | 10% | 100%
+        //  𐄂  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // Reason: approval and participation are too low
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 10% ! 510 | 10% | 100%
-        //     !  ✓  |  𐄂  |  ✓
+        // dur | tot | rel
+        // 510 | 10% | 100%
+        //  ✓  |  𐄂  |  ✓
         expect(await voting.canExecute(id)).to.equal(false); // vote end does not help
       });
 
@@ -456,55 +456,55 @@ describe.only('ERC20Voting', function () {
 
         await erc20VoteMock.mock.getPastVotes.returns(20);
         await voting.connect(signers[1]).vote(id, VoteOption.No, false);
-        // par ! dur | tot | rel
-        // 30% !  0  | 30% | 33%
-        //     !  𐄂  |  ✓  |  𐄂
+        // dur | tot | rel
+        //  0  | 30% | 33%
+        //  𐄂  |  ✓  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false); // approval too low, duration and support criterium are not met
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 30% ! 510 | 30% | 33%
-        //     !  ✓  |  ✓  |  𐄂
+        // dur | tot | rel
+        // 510 | 30% | 33%
+        //  ✓  |  ✓  |  𐄂
         expect(await voting.canExecute(id)).to.equal(false); // vote end does not help
       });
 
       it('executes after the duration if participation, and support criteria are met', async () => {
         await erc20VoteMock.mock.getPastVotes.returns(30);
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 30% !  0  | 30% | 100%
-        //     !  𐄂  |  ✓  |  ✓
-        expect(await voting.canExecute(id)).to.equal(false); // Reason: duration criterium is not met
+        // dur | tot | rel
+        //  0  | 30% | 100%
+        //  𐄂  |  ✓  |  ✓
+        expect(await voting.canExecute(id)).to.equal(false); // duration criterium is not met
 
         await ethers.provider.send('evm_increaseTime', [minDuration + 10]);
         await ethers.provider.send('evm_mine', []);
-        // par ! dur | tot | rel
-        // 30% ! 510 | 30% | 100%
-        //     !  ✓  |  ✓  |  ✓
+        // dur | tot | rel
+        // 510 | 30% | 100%
+        //  ✓  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // all criteria are met
       });
 
       it('executes early if the total support exceeds the relative support threshold (assuming the latter is > 50%)', async () => {
         await erc20VoteMock.mock.getPastVotes.returns(50);
         await voting.connect(signers[0]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 50% !  0  | 50% | 100%
-        //     !  𐄂  |  ✓  |  ✓
-        expect(await voting.canExecute(id)).to.equal(false); // Reason: app > supReq == false
+        // dur | tot | rel
+        //  0  | 50% | 100%
+        //  𐄂  |  ✓  |  ✓
+        expect(await voting.canExecute(id)).to.equal(false); // total support > relative support threshold == false
 
         await erc20VoteMock.mock.getPastVotes.returns(10);
         await voting.connect(signers[1]).vote(id, VoteOption.Yes, false);
-        // par ! dur | tot | rel
-        // 60% !  0  | 60% | 100%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 60% | 100%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // Correct because more voting doesn't change the outcome
 
         await erc20VoteMock.mock.getPastVotes.returns(40);
         await voting.connect(signers[2]).vote(id, VoteOption.No, false);
-        // par ! dur | tot | rel
-        //100% !  0  | 60% | 60%
-        //     !  𐄂  |  ✓  |  ✓
+        // dur | tot | rel
+        //  0  | 60% | 60%
+        //  𐄂  |  ✓  |  ✓
         expect(await voting.canExecute(id)).to.equal(true); // The outcome did not change
       });
     });

--- a/packages/contracts/test/voting/majority-voting.ts
+++ b/packages/contracts/test/voting/majority-voting.ts
@@ -35,13 +35,13 @@ describe('MajorityVotingMock', function () {
   });
 
   function initializeMock(
-    participationRequired: any,
+    totalSupportThresholdPct: any,
     supportRequired: any,
     minDuration: any
   ) {
     return votingBase.initializeMock(
       dao.address,
-      participationRequired,
+      totalSupportThresholdPct,
       supportRequired,
       minDuration
     );
@@ -71,13 +71,13 @@ describe('MajorityVotingMock', function () {
       await expect(
         votingBase.setConfiguration(1, pct16(1000), 3)
       ).to.be.revertedWith(
-        customError('VoteSupportExceeded', pct16(100), pct16(1000))
+        customError('PercentageExceeds100', pct16(100), pct16(1000))
       );
 
       await expect(
         votingBase.setConfiguration(pct16(1000), 2, 3)
       ).to.be.revertedWith(
-        customError('VoteParticipationExceeded', pct16(100), pct16(1000))
+        customError('PercentageExceeds100', pct16(100), pct16(1000))
       );
 
       await expect(votingBase.setConfiguration(1, 2, 0)).to.be.revertedWith(

--- a/packages/contracts/test/voting/majority-voting.ts
+++ b/packages/contracts/test/voting/majority-voting.ts
@@ -3,7 +3,8 @@ import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
 import {MajorityVotingMock, DAO} from '../../typechain';
-import {VOTING_EVENTS, pct16} from '../test-utils/voting';
+import {VOTING_EVENTS} from '../../utils/event';
+import {pct16} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 describe('MajorityVotingMock', function () {

--- a/packages/contracts/test/voting/majority-voting.ts
+++ b/packages/contracts/test/voting/majority-voting.ts
@@ -37,13 +37,13 @@ describe('MajorityVotingMock', function () {
   function initializeMock(
     totalSupportThresholdPct: any,
     supportRequired: any,
-    minDuration: any
+    voteDuration: any
   ) {
     return votingBase.initializeMock(
       dao.address,
       totalSupportThresholdPct,
       supportRequired,
-      minDuration
+      voteDuration
     );
   }
 

--- a/packages/contracts/test/voting/majority-voting.ts
+++ b/packages/contracts/test/voting/majority-voting.ts
@@ -2,22 +2,23 @@ import {expect} from 'chai';
 import {ethers} from 'hardhat';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
-import {MajorityVotingMock, DAOMock} from '../../typechain';
+import {MajorityVotingMock, DAO} from '../../typechain';
 import {VOTING_EVENTS, pct16} from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
 describe('MajorityVotingMock', function () {
   let signers: SignerWithAddress[];
   let votingBase: MajorityVotingMock;
-  let daoMock: DAOMock;
+  let dao: DAO;
   let ownerAddress: string;
 
   before(async () => {
     signers = await ethers.getSigners();
     ownerAddress = await signers[0].getAddress();
 
-    const DAOMock = await ethers.getContractFactory('DAOMock');
-    daoMock = await DAOMock.deploy(ownerAddress);
+    const DAO = await ethers.getContractFactory('DAO');
+    dao = await DAO.deploy();
+    await dao.initialize('0x', ownerAddress, ethers.constants.AddressZero);
   });
 
   beforeEach(async () => {
@@ -25,6 +26,11 @@ describe('MajorityVotingMock', function () {
       'MajorityVotingMock'
     );
     votingBase = await MajorityVotingBase.deploy();
+    dao.grant(
+      votingBase.address,
+      ownerAddress,
+      ethers.utils.id('SET_CONFIGURATION_PERMISSION')
+    );
   });
 
   function initializeMock(
@@ -33,7 +39,7 @@ describe('MajorityVotingMock', function () {
     minDuration: any
   ) {
     return votingBase.initializeMock(
-      daoMock.address,
+      dao.address,
       participationRequired,
       supportRequired,
       minDuration
@@ -56,7 +62,7 @@ describe('MajorityVotingMock', function () {
     });
   });
 
-  describe('setConfiguration: ', async () => {
+  describe('changeVoteConfig: ', async () => {
     beforeEach(async () => {
       await initializeMock(1, 2, 3);
     });

--- a/packages/contracts/utils/event.ts
+++ b/packages/contracts/utils/event.ts
@@ -11,3 +11,20 @@ export async function filterEvents(tx: any, eventName: string) {
 
   return event;
 }
+
+export const VOTING_EVENTS = {
+  CONFIG_UPDATED: 'ConfigUpdated',
+  VOTE_STARTED: 'VoteCreated',
+  VOTE_CAST: 'VoteCast',
+  VOTE_EXECUTED: 'VoteExecuted',
+};
+
+export const DAO_EVENTS = {
+  METADATA_SET: 'MetadataSet',
+  EXECUTED: 'Executed',
+  DEPOSITED: 'Deposited',
+  WITHDRAWN: 'Withdrawn',
+  STANDARD_CALLBACK_REGISTERED: 'StandardCallbackRegistered',
+  TRUSTED_FORWARDER_SET: 'TrustedForwarderSet',
+  SIGNATURE_VALIDATOR_SET: 'SignatureValidatorSet',
+};

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -236,7 +236,7 @@ type AllowlistProposal implements Proposal @entity {
   endDate: BigInt!
   snapshotBlock: BigInt!
   relativeSupportThresholdPct: BigInt!
-  participationRequired: BigInt!
+  totalSupportThresholdPct: BigInt!
   plenum: BigInt!
   yes: BigInt
   no: BigInt

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -145,7 +145,7 @@ type ERC20VotingPackage implements Package @entity {
   proposals: [ERC20VotingProposal!]! @derivedFrom(field: "pkg")
   relativeSupportThresholdPct: BigInt
   totalSupportThresholdPct: BigInt
-  minDuration: BigInt
+  voteDuration: BigInt
   votesLength: BigInt
   token: ERC20Token
   members: [ERC20VotingVoter!]! @derivedFrom(field: "pkg")
@@ -202,7 +202,7 @@ type AllowlistPackage implements Package @entity {
   proposals: [AllowlistProposal!]! @derivedFrom(field: "pkg")
   relativeSupportThresholdPct: BigInt
   totalSupportThresholdPct: BigInt
-  minDuration: BigInt
+  voteDuration: BigInt
   votesLength: BigInt
   members: [AllowlistVoter!]! @derivedFrom(field: "pkg")
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -143,8 +143,8 @@ type ERC20VotingPackage implements Package @entity {
   id: ID!
   daos: [DaoPackage!] @derivedFrom(field: "pkg")
   proposals: [ERC20VotingProposal!]! @derivedFrom(field: "pkg")
-  supportRequiredPct: BigInt
-  participationRequiredPct: BigInt
+  relativeSupportThresholdPct: BigInt
+  totalSupportThresholdPct: BigInt
   minDuration: BigInt
   votesLength: BigInt
   token: ERC20Token
@@ -180,13 +180,13 @@ type ERC20VotingProposal implements Proposal @entity {
   startDate: BigInt!
   endDate: BigInt!
   snapshotBlock: BigInt!
-  supportRequiredPct: BigInt!
-  participationRequiredPct: BigInt!
+  relativeSupportThresholdPct: BigInt!
+  totalSupportThresholdPct: BigInt!
   yes: BigInt
   no: BigInt
   abstain: BigInt
   voteCount: BigInt
-  votingPower: BigInt!
+  plenum: BigInt!
   voters: [ERC20Vote!]! @derivedFrom(field: "proposal")
   open: Boolean!
   executed: Boolean!
@@ -200,8 +200,8 @@ type AllowlistPackage implements Package @entity {
   id: ID!
   daos: [DaoPackage!] @derivedFrom(field: "pkg")
   proposals: [AllowlistProposal!]! @derivedFrom(field: "pkg")
-  supportRequiredPct: BigInt
-  participationRequiredPct: BigInt
+  relativeSupportThresholdPct: BigInt
+  totalSupportThresholdPct: BigInt
   minDuration: BigInt
   votesLength: BigInt
   members: [AllowlistVoter!]! @derivedFrom(field: "pkg")
@@ -235,9 +235,9 @@ type AllowlistProposal implements Proposal @entity {
   startDate: BigInt!
   endDate: BigInt!
   snapshotBlock: BigInt!
-  supportRequiredPct: BigInt!
+  relativeSupportThresholdPct: BigInt!
   participationRequired: BigInt!
-  votingPower: BigInt!
+  plenum: BigInt!
   yes: BigInt
   no: BigInt
   abstain: BigInt

--- a/packages/subgraph/src/dao/utils.ts
+++ b/packages/subgraph/src/dao/utils.ts
@@ -92,7 +92,7 @@ function createErc20VotingPackage(who: Address, daoId: string): void {
     let contract = ERC20VotingContract.bind(who);
     let relativeSupportThresholdPct = contract.try_relativeSupportThresholdPct();
     let totalSupportThresholdPct = contract.try_totalSupportThresholdPct();
-    let minDuration = contract.try_minDuration();
+    let voteDuration = contract.try_voteDuration();
     let token = contract.try_getVotingToken();
 
     packageEntity.relativeSupportThresholdPct = relativeSupportThresholdPct.reverted
@@ -101,7 +101,9 @@ function createErc20VotingPackage(who: Address, daoId: string): void {
     packageEntity.totalSupportThresholdPct = totalSupportThresholdPct.reverted
       ? null
       : totalSupportThresholdPct.value;
-    packageEntity.minDuration = minDuration.reverted ? null : minDuration.value;
+    packageEntity.voteDuration = voteDuration.reverted
+      ? null
+      : voteDuration.value;
 
     packageEntity.token = token.reverted ? null : handleERC20Token(token.value);
 
@@ -121,7 +123,7 @@ function createAllowlistVotingPackage(who: Address, daoId: string): void {
     let contract = AllowlistVotingContract.bind(who);
     let relativeSupportThresholdPct = contract.try_relativeSupportThresholdPct();
     let totalSupportThresholdPct = contract.try_totalSupportThresholdPct();
-    let minDuration = contract.try_minDuration();
+    let voteDuration = contract.try_voteDuration();
 
     packageEntity.relativeSupportThresholdPct = relativeSupportThresholdPct.reverted
       ? null
@@ -129,7 +131,9 @@ function createAllowlistVotingPackage(who: Address, daoId: string): void {
     packageEntity.totalSupportThresholdPct = totalSupportThresholdPct.reverted
       ? null
       : totalSupportThresholdPct.value;
-    packageEntity.minDuration = minDuration.reverted ? null : minDuration.value;
+    packageEntity.voteDuration = voteDuration.reverted
+      ? null
+      : voteDuration.value;
 
     // Create template
     let context = new DataSourceContext();

--- a/packages/subgraph/src/dao/utils.ts
+++ b/packages/subgraph/src/dao/utils.ts
@@ -90,17 +90,17 @@ function createErc20VotingPackage(who: Address, daoId: string): void {
   if (!packageEntity) {
     packageEntity = new ERC20VotingPackage(who.toHexString());
     let contract = ERC20VotingContract.bind(who);
-    let supportRequiredPct = contract.try_supportRequiredPct();
-    let participationRequiredPct = contract.try_participationRequiredPct();
+    let relativeSupportThresholdPct = contract.try_relativeSupportThresholdPct();
+    let totalSupportThresholdPct = contract.try_totalSupportThresholdPct();
     let minDuration = contract.try_minDuration();
     let token = contract.try_getVotingToken();
 
-    packageEntity.supportRequiredPct = supportRequiredPct.reverted
+    packageEntity.relativeSupportThresholdPct = relativeSupportThresholdPct.reverted
       ? null
-      : supportRequiredPct.value;
-    packageEntity.participationRequiredPct = participationRequiredPct.reverted
+      : relativeSupportThresholdPct.value;
+    packageEntity.totalSupportThresholdPct = totalSupportThresholdPct.reverted
       ? null
-      : participationRequiredPct.value;
+      : totalSupportThresholdPct.value;
     packageEntity.minDuration = minDuration.reverted ? null : minDuration.value;
 
     packageEntity.token = token.reverted ? null : handleERC20Token(token.value);
@@ -119,16 +119,16 @@ function createAllowlistVotingPackage(who: Address, daoId: string): void {
   if (!packageEntity) {
     packageEntity = new AllowlistPackage(who.toHexString());
     let contract = AllowlistVotingContract.bind(who);
-    let supportRequiredPct = contract.try_supportRequiredPct();
-    let participationRequiredPct = contract.try_participationRequiredPct();
+    let relativeSupportThresholdPct = contract.try_relativeSupportThresholdPct();
+    let totalSupportThresholdPct = contract.try_totalSupportThresholdPct();
     let minDuration = contract.try_minDuration();
 
-    packageEntity.supportRequiredPct = supportRequiredPct.reverted
+    packageEntity.relativeSupportThresholdPct = relativeSupportThresholdPct.reverted
       ? null
-      : supportRequiredPct.value;
-    packageEntity.participationRequiredPct = participationRequiredPct.reverted
+      : relativeSupportThresholdPct.value;
+    packageEntity.totalSupportThresholdPct = totalSupportThresholdPct.reverted
       ? null
-      : participationRequiredPct.value;
+      : totalSupportThresholdPct.value;
     packageEntity.minDuration = minDuration.reverted ? null : minDuration.value;
 
     // Create template

--- a/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
+++ b/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
@@ -188,7 +188,7 @@ export function handleConfigUpdated(event: ConfigUpdated): void {
       event.params.totalSupportThresholdPct;
     packageEntity.relativeSupportThresholdPct =
       event.params.relativeSupportThresholdPct;
-    packageEntity.minDuration = event.params.minDuration;
+    packageEntity.voteDuration = event.params.voteDuration;
     packageEntity.save();
   }
 }

--- a/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
+++ b/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
@@ -52,7 +52,7 @@ export function _handleVoteCreated(
     proposalEntity.endDate = vote.value.value3;
     proposalEntity.snapshotBlock = vote.value.value4;
     proposalEntity.relativeSupportThresholdPct = vote.value.value5;
-    proposalEntity.participationRequired = vote.value.value6;
+    proposalEntity.totalSupportThresholdPct = vote.value.value6;
     proposalEntity.plenum = vote.value.value7;
 
     // actions
@@ -122,8 +122,8 @@ export function handleVoteCast(event: VoteCast): void {
 
       // check if the current vote results meet
       // the conditions for the proposal to pass:
-      // - Minimum participation => => (totalVotes / plenum) >= minParticipation
-      // - Minimum suport => (yes / totalVotes) >= minSupport
+      // - total support    :  N_yes / N_total >= total support threshold
+      // - relative support :  N_yes / (N_yes + N_no) >= relative support threshold
 
       // expect a number between 0 and 100
       // where 0.35 => 35
@@ -136,7 +136,7 @@ export function handleVoteCast(event: VoteCast): void {
       // set the executable param
       proposalEntity.executable =
         currentParticipation.ge(
-          proposalEntity.participationRequired.div(
+          proposalEntity.totalSupportThresholdPct.div(
             BigInt.fromString(TEN_POWER_16)
           )
         ) &&

--- a/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
+++ b/packages/subgraph/src/packages/allowlist/allowlist-voting.ts
@@ -51,9 +51,9 @@ export function _handleVoteCreated(
     proposalEntity.startDate = vote.value.value2;
     proposalEntity.endDate = vote.value.value3;
     proposalEntity.snapshotBlock = vote.value.value4;
-    proposalEntity.supportRequiredPct = vote.value.value5;
+    proposalEntity.relativeSupportThresholdPct = vote.value.value5;
     proposalEntity.participationRequired = vote.value.value6;
-    proposalEntity.votingPower = vote.value.value7;
+    proposalEntity.plenum = vote.value.value7;
 
     // actions
     let actions = vote.value.value11;
@@ -122,14 +122,14 @@ export function handleVoteCast(event: VoteCast): void {
 
       // check if the current vote results meet
       // the conditions for the proposal to pass:
-      // - Minimum participation => => (totalVotes / votingPower) >= minParticipation
+      // - Minimum participation => => (totalVotes / plenum) >= minParticipation
       // - Minimum suport => (yes / totalVotes) >= minSupport
 
       // expect a number between 0 and 100
       // where 0.35 => 35
       let currentParticipation = voteCount
         .times(BigInt.fromI32(100))
-        .div(proposalEntity.votingPower);
+        .div(proposalEntity.plenum);
       // expect a number between 0 and 100
       // where 0.35 => 35
       let currentSupport = yes.times(BigInt.fromI32(100)).div(voteCount);
@@ -141,7 +141,9 @@ export function handleVoteCast(event: VoteCast): void {
           )
         ) &&
         currentSupport.ge(
-          proposalEntity.supportRequiredPct.div(BigInt.fromString(TEN_POWER_16))
+          proposalEntity.relativeSupportThresholdPct.div(
+            BigInt.fromString(TEN_POWER_16)
+          )
         );
       proposalEntity.save();
     }
@@ -182,9 +184,10 @@ export function handleVoteExecuted(event: VoteExecuted): void {
 export function handleConfigUpdated(event: ConfigUpdated): void {
   let packageEntity = AllowlistPackage.load(event.address.toHexString());
   if (packageEntity) {
-    packageEntity.participationRequiredPct =
-      event.params.participationRequiredPct;
-    packageEntity.supportRequiredPct = event.params.supportRequiredPct;
+    packageEntity.totalSupportThresholdPct =
+      event.params.totalSupportThresholdPct;
+    packageEntity.relativeSupportThresholdPct =
+      event.params.relativeSupportThresholdPct;
     packageEntity.minDuration = event.params.minDuration;
     packageEntity.save();
   }

--- a/packages/subgraph/src/packages/erc20/erc20-voting.ts
+++ b/packages/subgraph/src/packages/erc20/erc20-voting.ts
@@ -133,8 +133,8 @@ export function handleVoteCast(event: VoteCast): void {
       proposalEntity.voteCount = voteCount;
       // check if the current vote results meet
       // the conditions for the proposal to pass:
-      // - Minimum participation => => (totalVotes / plenum) >= minParticipation
-      // - Minimum suport => (yes / totalVotes) >= minSupport
+      // - total support    :  N_yes / N_total >= total support threshold
+      // - relative support :  N_yes / (N_yes + N_no) >= relative support threshold
 
       // expect a number between 0 and 100
       // where 0.35 => 35

--- a/packages/subgraph/src/packages/erc20/erc20-voting.ts
+++ b/packages/subgraph/src/packages/erc20/erc20-voting.ts
@@ -199,7 +199,7 @@ export function handleConfigUpdated(event: ConfigUpdated): void {
       event.params.relativeSupportThresholdPct;
     packageEntity.totalSupportThresholdPct =
       event.params.totalSupportThresholdPct;
-    packageEntity.minDuration = event.params.minDuration;
+    packageEntity.voteDuration = event.params.voteDuration;
     packageEntity.save();
   }
 }

--- a/packages/subgraph/src/packages/erc20/erc20-voting.ts
+++ b/packages/subgraph/src/packages/erc20/erc20-voting.ts
@@ -50,9 +50,9 @@ export function _handleVoteCreated(
     proposalEntity.startDate = vote.value.value2;
     proposalEntity.endDate = vote.value.value3;
     proposalEntity.snapshotBlock = vote.value.value4;
-    proposalEntity.supportRequiredPct = vote.value.value5;
-    proposalEntity.participationRequiredPct = vote.value.value6;
-    proposalEntity.votingPower = vote.value.value7;
+    proposalEntity.relativeSupportThresholdPct = vote.value.value5;
+    proposalEntity.totalSupportThresholdPct = vote.value.value6;
+    proposalEntity.plenum = vote.value.value7;
 
     // actions
     let actions = vote.value.value11;
@@ -133,26 +133,28 @@ export function handleVoteCast(event: VoteCast): void {
       proposalEntity.voteCount = voteCount;
       // check if the current vote results meet
       // the conditions for the proposal to pass:
-      // - Minimum participation => => (totalVotes / votingPower) >= minParticipation
+      // - Minimum participation => => (totalVotes / plenum) >= minParticipation
       // - Minimum suport => (yes / totalVotes) >= minSupport
 
       // expect a number between 0 and 100
       // where 0.35 => 35
       let currentParticipation = voteCount
         .times(BigInt.fromI32(100))
-        .div(proposalEntity.votingPower);
+        .div(proposalEntity.plenum);
       // expect a number between 0 and 100
       // where 0.35 => 35
       let currentSupport = yes.times(BigInt.fromI32(100)).div(voteCount);
       // set the executable param
       proposalEntity.executable =
         currentParticipation.ge(
-          proposalEntity.participationRequiredPct.div(
+          proposalEntity.totalSupportThresholdPct.div(
             BigInt.fromString(TEN_POWER_16)
           )
         ) &&
         currentSupport.ge(
-          proposalEntity.supportRequiredPct.div(BigInt.fromString(TEN_POWER_16))
+          proposalEntity.relativeSupportThresholdPct.div(
+            BigInt.fromString(TEN_POWER_16)
+          )
         );
       proposalEntity.save();
     }
@@ -193,9 +195,10 @@ export function handleVoteExecuted(event: VoteExecuted): void {
 export function handleConfigUpdated(event: ConfigUpdated): void {
   let packageEntity = ERC20VotingPackage.load(event.address.toHexString());
   if (packageEntity) {
-    packageEntity.supportRequiredPct = event.params.supportRequiredPct;
-    packageEntity.participationRequiredPct =
-      event.params.participationRequiredPct;
+    packageEntity.relativeSupportThresholdPct =
+      event.params.relativeSupportThresholdPct;
+    packageEntity.totalSupportThresholdPct =
+      event.params.totalSupportThresholdPct;
     packageEntity.minDuration = event.params.minDuration;
     packageEntity.save();
   }

--- a/packages/subgraph/tests/allowlist-voting/allowlist-voting.test.ts
+++ b/packages/subgraph/tests/allowlist-voting/allowlist-voting.test.ts
@@ -261,7 +261,7 @@ test('Run Allowlist Voting (handleConfigUpdated) mappings with mock event', () =
     'relativeSupportThresholdPct',
     '1'
   );
-  assert.fieldEquals('AllowlistPackage', entityID, 'minDuration', '3600');
+  assert.fieldEquals('AllowlistPackage', entityID, 'voteDuration', '3600');
 
   clearStore();
 });

--- a/packages/subgraph/tests/allowlist-voting/allowlist-voting.test.ts
+++ b/packages/subgraph/tests/allowlist-voting/allowlist-voting.test.ts
@@ -42,9 +42,9 @@ let voteId = '0';
 let startDate = '1644851000';
 let endDate = '1644852000';
 let snapshotBlock = '100';
-let supportRequiredPct = '1000';
-let participationRequiredPct = '500';
-let votingPower = '1000';
+let relativeSupportThresholdPct = '1000';
+let totalSupportThresholdPct = '500';
+let plenum = '1000';
 let actions = createDummyActions(DAO_TOKEN_ADDRESS, '0', '0x00000000');
 
 test('Run Allowlist Voting (handleVoteCreated) mappings with mock event', () => {
@@ -64,9 +64,9 @@ test('Run Allowlist Voting (handleVoteCreated) mappings with mock event', () => 
     startDate,
     endDate,
     snapshotBlock,
-    supportRequiredPct,
-    participationRequiredPct,
-    votingPower,
+    relativeSupportThresholdPct,
+    totalSupportThresholdPct,
+    plenum,
     '0',
     '0',
     '0',
@@ -107,10 +107,10 @@ test('Run Allowlist Voting (handleVoteCreated) mappings with mock event', () => 
   assert.fieldEquals(
     'AllowlistProposal',
     entityID,
-    'supportRequiredPct',
-    supportRequiredPct
+    'relativeSupportThresholdPct',
+    relativeSupportThresholdPct
   );
-  // assert.fieldEquals('AllowlistProposal', entityID, 'votingPower', votingPower);
+  // assert.fieldEquals('AllowlistProposal', entityID, 'plenum', plenum);
   assert.fieldEquals('AllowlistProposal', entityID, 'executed', 'false');
 
   // chack AllowlistPackage
@@ -252,10 +252,15 @@ test('Run Allowlist Voting (handleConfigUpdated) mappings with mock event', () =
   assert.fieldEquals(
     'AllowlistPackage',
     entityID,
-    'participationRequiredPct',
+    'totalSupportThresholdPct',
     '2'
   );
-  assert.fieldEquals('AllowlistPackage', entityID, 'supportRequiredPct', '1');
+  assert.fieldEquals(
+    'AllowlistPackage',
+    entityID,
+    'relativeSupportThresholdPct',
+    '1'
+  );
   assert.fieldEquals('AllowlistPackage', entityID, 'minDuration', '3600');
 
   clearStore();

--- a/packages/subgraph/tests/allowlist-voting/utils.ts
+++ b/packages/subgraph/tests/allowlist-voting/utils.ts
@@ -236,7 +236,7 @@ export function createAllowlistProposalEntityState(
   allowlistProposal.relativeSupportThresholdPct = BigInt.fromString(
     relativeSupportThresholdPct
   );
-  allowlistProposal.participationRequired = BigInt.fromString(
+  allowlistProposal.totalSupportThresholdPct = BigInt.fromString(
     totalSupportThresholdPct
   );
   allowlistProposal.plenum = BigInt.fromString(plenum);

--- a/packages/subgraph/tests/allowlist-voting/utils.ts
+++ b/packages/subgraph/tests/allowlist-voting/utils.ts
@@ -120,8 +120,8 @@ export function createNewVoteExecutedEvent(
 }
 
 export function createNewConfigUpdatedEvent(
-  participationRequiredPct: string,
-  supportRequiredPct: string,
+  totalSupportThresholdPct: string,
+  relativeSupportThresholdPct: string,
   minDuration: string,
   contractAddress: string
 ): ConfigUpdated {
@@ -130,21 +130,23 @@ export function createNewConfigUpdatedEvent(
   newConfigUpdatedEvent.address = Address.fromString(contractAddress);
   newConfigUpdatedEvent.parameters = [];
 
-  let participationRequiredPctParam = new ethereum.EventParam(
-    'participationRequiredPct',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(participationRequiredPct))
+  let totalSupportThresholdPctParam = new ethereum.EventParam(
+    'totalSupportThresholdPct',
+    ethereum.Value.fromSignedBigInt(BigInt.fromString(totalSupportThresholdPct))
   );
-  let supportRequiredPctParam = new ethereum.EventParam(
-    'supportRequiredPct',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(supportRequiredPct))
+  let relativeSupportThresholdPctParam = new ethereum.EventParam(
+    'relativeSupportThresholdPct',
+    ethereum.Value.fromSignedBigInt(
+      BigInt.fromString(relativeSupportThresholdPct)
+    )
   );
   let minDurationParam = new ethereum.EventParam(
     'minDuration',
     ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
   );
 
-  newConfigUpdatedEvent.parameters.push(participationRequiredPctParam);
-  newConfigUpdatedEvent.parameters.push(supportRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(totalSupportThresholdPctParam);
+  newConfigUpdatedEvent.parameters.push(relativeSupportThresholdPctParam);
   newConfigUpdatedEvent.parameters.push(minDurationParam);
 
   return newConfigUpdatedEvent;
@@ -214,9 +216,9 @@ export function createAllowlistProposalEntityState(
   startDate: string = START_DATE,
   endDate: string = END_DATE,
   snapshotBlock: string = SNAPSHOT_BLOCK,
-  supportRequiredPct: string = MIN_SUPPORT,
-  participationRequiredPct: string = MIN_TURNOUT,
-  votingPower: string = VOTING_POWER,
+  relativeSupportThresholdPct: string = MIN_SUPPORT,
+  totalSupportThresholdPct: string = MIN_TURNOUT,
+  plenum: string = VOTING_POWER,
   createdAt: string = CREATED_AT,
   open: boolean = true,
   executable: boolean = false,
@@ -231,11 +233,13 @@ export function createAllowlistProposalEntityState(
   allowlistProposal.startDate = BigInt.fromString(startDate);
   allowlistProposal.endDate = BigInt.fromString(endDate);
   allowlistProposal.snapshotBlock = BigInt.fromString(snapshotBlock);
-  allowlistProposal.supportRequiredPct = BigInt.fromString(supportRequiredPct);
-  allowlistProposal.participationRequired = BigInt.fromString(
-    participationRequiredPct
+  allowlistProposal.relativeSupportThresholdPct = BigInt.fromString(
+    relativeSupportThresholdPct
   );
-  allowlistProposal.votingPower = BigInt.fromString(votingPower);
+  allowlistProposal.participationRequired = BigInt.fromString(
+    totalSupportThresholdPct
+  );
+  allowlistProposal.plenum = BigInt.fromString(plenum);
   allowlistProposal.open = open;
   allowlistProposal.executable = executable;
   allowlistProposal.executed = executed;

--- a/packages/subgraph/tests/allowlist-voting/utils.ts
+++ b/packages/subgraph/tests/allowlist-voting/utils.ts
@@ -122,7 +122,7 @@ export function createNewVoteExecutedEvent(
 export function createNewConfigUpdatedEvent(
   totalSupportThresholdPct: string,
   relativeSupportThresholdPct: string,
-  minDuration: string,
+  voteDuration: string,
   contractAddress: string
 ): ConfigUpdated {
   let newConfigUpdatedEvent = changetype<ConfigUpdated>(newMockEvent());
@@ -140,14 +140,14 @@ export function createNewConfigUpdatedEvent(
       BigInt.fromString(relativeSupportThresholdPct)
     )
   );
-  let minDurationParam = new ethereum.EventParam(
-    'minDuration',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
+  let voteDurationParam = new ethereum.EventParam(
+    'voteDuration',
+    ethereum.Value.fromSignedBigInt(BigInt.fromString(voteDuration))
   );
 
   newConfigUpdatedEvent.parameters.push(totalSupportThresholdPctParam);
   newConfigUpdatedEvent.parameters.push(relativeSupportThresholdPctParam);
-  newConfigUpdatedEvent.parameters.push(minDurationParam);
+  newConfigUpdatedEvent.parameters.push(voteDurationParam);
 
   return newConfigUpdatedEvent;
 }

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -345,7 +345,9 @@ export function createStandardCallbackRegisteredEvent(
 
   let callbackSelectorParam = new ethereum.EventParam(
     'callbackSelector',
-    ethereum.Value.fromFixedBytes(Bytes.fromHexString(callbackSelector) as Bytes)
+    ethereum.Value.fromFixedBytes(
+      Bytes.fromHexString(callbackSelector) as Bytes
+    )
   );
 
   let magicNumberParam = new ethereum.EventParam(
@@ -407,8 +409,8 @@ export function getSupportRequiredPct(
 ): void {
   createMockedFunction(
     Address.fromString(contractAddress),
-    'supportRequiredPct',
-    'supportRequiredPct():(uint64)'
+    'relativeSupportThresholdPct',
+    'relativeSupportThresholdPct():(uint64)'
   )
     .withArgs([])
     .returns([ethereum.Value.fromSignedBigInt(returns)]);
@@ -420,8 +422,8 @@ export function getParticipationRequiredPct(
 ): void {
   createMockedFunction(
     Address.fromString(contractAddress),
-    'participationRequiredPct',
-    'participationRequiredPct():(uint64)'
+    'totalSupportThresholdPct',
+    'totalSupportThresholdPct():(uint64)'
   )
     .withArgs([])
     .returns([ethereum.Value.fromSignedBigInt(returns)]);

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -432,8 +432,8 @@ export function getParticipationRequiredPct(
 export function getMinDuration(contractAddress: string, returns: BigInt): void {
   createMockedFunction(
     Address.fromString(contractAddress),
-    'minDuration',
-    'minDuration():(uint64)'
+    'voteDuration',
+    'voteDuration():(uint64)'
   )
     .withArgs([])
     .returns([ethereum.Value.fromSignedBigInt(returns)]);

--- a/packages/subgraph/tests/erc20-voting/erc20-voting.test.ts
+++ b/packages/subgraph/tests/erc20-voting/erc20-voting.test.ts
@@ -37,9 +37,9 @@ let voteId = '0';
 let startDate = '1644851000';
 let endDate = '1644852000';
 let snapshotBlock = '100';
-let supportRequiredPct = '1000';
-let participationRequiredPct = '500';
-let votingPower = '1000';
+let relativeSupportThresholdPct = '1000';
+let totalSupportThresholdPct = '500';
+let plenum = '1000';
 let actions = createDummyActions(DAO_TOKEN_ADDRESS, '0', '0x00000000');
 
 test('Run ERC Voting (handleVoteCreated) mappings with mock event', () => {
@@ -59,9 +59,9 @@ test('Run ERC Voting (handleVoteCreated) mappings with mock event', () => {
     startDate,
     endDate,
     snapshotBlock,
-    supportRequiredPct,
-    participationRequiredPct,
-    votingPower,
+    relativeSupportThresholdPct,
+    totalSupportThresholdPct,
+    plenum,
     '0',
     '0',
     '0',
@@ -108,21 +108,16 @@ test('Run ERC Voting (handleVoteCreated) mappings with mock event', () => {
   assert.fieldEquals(
     'ERC20VotingProposal',
     entityID,
-    'supportRequiredPct',
-    supportRequiredPct
+    'relativeSupportThresholdPct',
+    relativeSupportThresholdPct
   );
   assert.fieldEquals(
     'ERC20VotingProposal',
     entityID,
-    'participationRequiredPct',
-    participationRequiredPct
+    'totalSupportThresholdPct',
+    totalSupportThresholdPct
   );
-  assert.fieldEquals(
-    'ERC20VotingProposal',
-    entityID,
-    'votingPower',
-    votingPower
-  );
+  assert.fieldEquals('ERC20VotingProposal', entityID, 'plenum', plenum);
   assert.fieldEquals('ERC20VotingProposal', entityID, 'executed', 'false');
 
   // chack ERC20VotingPackage
@@ -261,9 +256,9 @@ test('Run ERC Voting (handleVoteExecuted) mappings with mock event', () => {
     startDate,
     endDate,
     snapshotBlock,
-    supportRequiredPct,
-    participationRequiredPct,
-    votingPower,
+    relativeSupportThresholdPct,
+    totalSupportThresholdPct,
+    plenum,
     '1',
     '0',
     '0',
@@ -297,11 +292,16 @@ test('Run ERC Voting (handleConfigUpdated) mappings with mock event', () => {
 
   // checks
   assert.fieldEquals('ERC20VotingPackage', entityID, 'id', entityID);
-  assert.fieldEquals('ERC20VotingPackage', entityID, 'supportRequiredPct', '1');
   assert.fieldEquals(
     'ERC20VotingPackage',
     entityID,
-    'participationRequiredPct',
+    'relativeSupportThresholdPct',
+    '1'
+  );
+  assert.fieldEquals(
+    'ERC20VotingPackage',
+    entityID,
+    'totalSupportThresholdPct',
     '2'
   );
   assert.fieldEquals('ERC20VotingPackage', entityID, 'minDuration', '3600');

--- a/packages/subgraph/tests/erc20-voting/erc20-voting.test.ts
+++ b/packages/subgraph/tests/erc20-voting/erc20-voting.test.ts
@@ -304,7 +304,7 @@ test('Run ERC Voting (handleConfigUpdated) mappings with mock event', () => {
     'totalSupportThresholdPct',
     '2'
   );
-  assert.fieldEquals('ERC20VotingPackage', entityID, 'minDuration', '3600');
+  assert.fieldEquals('ERC20VotingPackage', entityID, 'voteDuration', '3600');
 
   clearStore();
 });

--- a/packages/subgraph/tests/erc20-voting/utils.ts
+++ b/packages/subgraph/tests/erc20-voting/utils.ts
@@ -118,8 +118,8 @@ export function createNewVoteExecutedEvent(
 }
 
 export function createNewConfigUpdatedEvent(
-  supportRequiredPct: string,
-  participationRequiredPct: string,
+  relativeSupportThresholdPct: string,
+  totalSupportThresholdPct: string,
   minDuration: string,
   contractAddress: string
 ): ConfigUpdated {
@@ -128,21 +128,23 @@ export function createNewConfigUpdatedEvent(
   newConfigUpdatedEvent.address = Address.fromString(contractAddress);
   newConfigUpdatedEvent.parameters = [];
 
-  let participationRequiredPctParam = new ethereum.EventParam(
-    'participationRequiredPct',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(participationRequiredPct))
+  let totalSupportThresholdPctParam = new ethereum.EventParam(
+    'totalSupportThresholdPct',
+    ethereum.Value.fromSignedBigInt(BigInt.fromString(totalSupportThresholdPct))
   );
-  let supportRequiredPctParam = new ethereum.EventParam(
-    'supportRequiredPct',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(supportRequiredPct))
+  let relativeSupportThresholdPctParam = new ethereum.EventParam(
+    'relativeSupportThresholdPct',
+    ethereum.Value.fromSignedBigInt(
+      BigInt.fromString(relativeSupportThresholdPct)
+    )
   );
   let minDurationParam = new ethereum.EventParam(
     'minDuration',
     ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
   );
 
-  newConfigUpdatedEvent.parameters.push(participationRequiredPctParam);
-  newConfigUpdatedEvent.parameters.push(supportRequiredPctParam);
+  newConfigUpdatedEvent.parameters.push(totalSupportThresholdPctParam);
+  newConfigUpdatedEvent.parameters.push(relativeSupportThresholdPctParam);
   newConfigUpdatedEvent.parameters.push(minDurationParam);
 
   return newConfigUpdatedEvent;
@@ -174,9 +176,9 @@ export function createERC20VotingProposalEntityState(
   startDate: string = START_DATE,
   endDate: string = END_DATE,
   snapshotBlock: string = SNAPSHOT_BLOCK,
-  supportRequiredPct: string = MIN_SUPPORT,
-  participationRequiredPct: string = MIN_TURNOUT,
-  votingPower: string = VOTING_POWER,
+  relativeSupportThresholdPct: string = MIN_SUPPORT,
+  totalSupportThresholdPct: string = MIN_TURNOUT,
+  plenum: string = VOTING_POWER,
   createdAt: string = CREATED_AT,
   open: boolean = true,
   executable: boolean = false,
@@ -191,13 +193,13 @@ export function createERC20VotingProposalEntityState(
   erc20VotingProposal.startDate = BigInt.fromString(startDate);
   erc20VotingProposal.endDate = BigInt.fromString(endDate);
   erc20VotingProposal.snapshotBlock = BigInt.fromString(snapshotBlock);
-  erc20VotingProposal.supportRequiredPct = BigInt.fromString(
-    supportRequiredPct
+  erc20VotingProposal.relativeSupportThresholdPct = BigInt.fromString(
+    relativeSupportThresholdPct
   );
-  erc20VotingProposal.participationRequiredPct = BigInt.fromString(
-    participationRequiredPct
+  erc20VotingProposal.totalSupportThresholdPct = BigInt.fromString(
+    totalSupportThresholdPct
   );
-  erc20VotingProposal.votingPower = BigInt.fromString(votingPower);
+  erc20VotingProposal.plenum = BigInt.fromString(plenum);
   erc20VotingProposal.open = open;
   erc20VotingProposal.executable = executable;
   erc20VotingProposal.executed = executed;

--- a/packages/subgraph/tests/erc20-voting/utils.ts
+++ b/packages/subgraph/tests/erc20-voting/utils.ts
@@ -120,7 +120,7 @@ export function createNewVoteExecutedEvent(
 export function createNewConfigUpdatedEvent(
   relativeSupportThresholdPct: string,
   totalSupportThresholdPct: string,
-  minDuration: string,
+  voteDuration: string,
   contractAddress: string
 ): ConfigUpdated {
   let newConfigUpdatedEvent = changetype<ConfigUpdated>(newMockEvent());
@@ -138,14 +138,14 @@ export function createNewConfigUpdatedEvent(
       BigInt.fromString(relativeSupportThresholdPct)
     )
   );
-  let minDurationParam = new ethereum.EventParam(
-    'minDuration',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(minDuration))
+  let voteDurationParam = new ethereum.EventParam(
+    'voteDuration',
+    ethereum.Value.fromSignedBigInt(BigInt.fromString(voteDuration))
   );
 
   newConfigUpdatedEvent.parameters.push(totalSupportThresholdPctParam);
   newConfigUpdatedEvent.parameters.push(relativeSupportThresholdPctParam);
-  newConfigUpdatedEvent.parameters.push(minDurationParam);
+  newConfigUpdatedEvent.parameters.push(voteDurationParam);
 
   return newConfigUpdatedEvent;
 }

--- a/packages/subgraph/tests/utils.ts
+++ b/packages/subgraph/tests/utils.ts
@@ -59,7 +59,7 @@ export function createGetVoteCall(
   snapshotBlock: string,
   supportRequired: string,
   participationRequired: string,
-  votingPower: string,
+  plenum: string,
   yes: string,
   no: string,
   abstain: string,
@@ -81,7 +81,7 @@ export function createGetVoteCall(
       ethereum.Value.fromUnsignedBigInt(
         BigInt.fromString(participationRequired)
       ),
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromString(votingPower)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString(plenum)),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(yes)),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(no)),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(abstain)),

--- a/packages/subgraph/tests/utils.ts
+++ b/packages/subgraph/tests/utils.ts
@@ -58,7 +58,7 @@ export function createGetVoteCall(
   endDate: string,
   snapshotBlock: string,
   supportRequired: string,
-  participationRequired: string,
+  totalSupportThresholdPct: string,
   plenum: string,
   yes: string,
   no: string,
@@ -79,7 +79,7 @@ export function createGetVoteCall(
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(snapshotBlock)),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(supportRequired)),
       ethereum.Value.fromUnsignedBigInt(
-        BigInt.fromString(participationRequired)
+        BigInt.fromString(totalSupportThresholdPct)
       ),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(plenum)),
       ethereum.Value.fromUnsignedBigInt(BigInt.fromString(yes)),


### PR DESCRIPTION
## Description
Before this PR, the execution logic could lead to unexpected and unintuitive vote ends for certain parameter settings.

This PR fixes and clarifies the execution logic by replacing the quantity `participation = (N_yes + N_no + N_abstain)/N_total` 
by `total support = N_yes / N_total`.
In particular, early execution is now only allowed iff (if and only if) the vote outcome cannot change anymore.

For more information, see the task description of: [APP-431](https://aragonassociation.atlassian.net/browse/APP-431) and related subtasks.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.