### PR TITLE
Fix wrong relative support calculation differing from the comments

### DIFF
--- a/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
+++ b/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol
@@ -271,7 +271,7 @@ abstract contract MajorityVotingBase is
         }
 
         // Criterium 3: The relative support is greater than the relative support threshold
-        uint256 relativeSupportPct = _calculatePct(vote_.yes, vote_.yes + vote_.no + vote_.abstain);
+        uint256 relativeSupportPct = _calculatePct(vote_.yes, vote_.yes + vote_.no);
         if (relativeSupportPct <= vote_.relativeSupportThresholdPct) {
             return false;
         }


### PR DESCRIPTION
## Description

In https://github.com/aragon/core/pull/141, it was written that we use 
$$\text{relative support} = N_\text{yes} / (N_\text{yes} + N_\text{no})$$
https://github.com/aragon/core/blob/c498623e06ac84ae1d948eba46038a7b7d38a46c/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol#L17
but this was not changed in the respective line. https://github.com/aragon/core/blob/c498623e06ac84ae1d948eba46038a7b7d38a46c/packages/contracts/contracts/voting/majority/MajorityVotingBase.sol#L274

This PR fixes this mistake by removing `vote_.abstain`.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.