### PR TITLE
fix: sugraph erc20 voting support calc crash

### DIFF
--- a/packages/subgraph/src/packages/erc20/erc20-voting.ts
+++ b/packages/subgraph/src/packages/erc20/erc20-voting.ts
@@ -143,7 +143,10 @@ export function handleVoteCast(event: VoteCast): void {
         .div(proposalEntity.census);
       // expect a number between 0 and 100
       // where 0.35 => 35
-      let currentSupport = yes.times(BigInt.fromI32(100)).div(voteCount);
+      let currentSupport = new BigInt(0);
+      if(voteCount.gt(new BigInt(0))) {
+        currentSupport = yes.times(BigInt.fromI32(100)).div(voteCount);
+      }
       // set the executable param
       proposalEntity.executable =
         currentParticipation.ge(


### PR DESCRIPTION
## Description

- Fixes bug in sugraph support calculation where the subgraph crashes when no votes were cast

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.