### PR TITLE
Adds gas reporting environment variables to the .env example

### DIFF
--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -2,10 +2,15 @@ ETH_KEY=<Private-Key>
 ETHERSCAN_KEY=<Etherscan-Api-Key>
 POLYGONSCAN_KEY=<Polygonscan-Api-Key>
 ARBISCAN_KEY=<Arbiscan-Api-Key>
+
+REPORT_GAS=<Report-Gas example: true>
+COINMARKETCAP_API_KEY=<Coinmarketcap-Api-Key>
+
 MAINNET_DAO_ENS_DOMAIN=<ENS-Domain example: dao.eth>
 GOERLI_DAO_ENS_DOMAIN=<ENS-Domain example: dao.eth>
 LOCALHOST_DAO_ENS_DOMAIN=<ENS-Domain example: dao.eth>
 HARDHAT_DAO_ENS_DOMAIN=<ENS-Domain example: dao.eth>
+
 MAINNET_PLUGIN_ENS_DOMAIN=<ENS-Domain example: dao.eth>
 GOERLI_PLUGIN_ENS_DOMAIN=<ENS-Domain example: dao.eth>
 LOCALHOST_PLUGIN_ENS_DOMAIN=<ENS-Domain example: dao.eth>

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -55,6 +55,7 @@ const config: HardhatUserConfig = {
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS !== undefined,
+    coinmarketcap: process.env.COINMARKETCAP_API_KEY,
     currency: 'USD',
   },
   etherscan: {


### PR DESCRIPTION
## Description
Let's be more aware of gas costs. 
Setting `REPORT_GAS` prints the gas report after `yarn test`.
Setting `COINMARKETCAP_API_KEY` with a Coinmarketcap API key prints the USD equivalent.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have tested my code on the test network.