### PR TITLE
fix: don't store None votes in subgraph

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UPCOMING]
 
+### Changed
+- Ignores `None` votes from addresslist voting and token voting
+
 ## 0.5.0-alpha
 
 On 2022-12-09 15:16:22

--- a/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
+++ b/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
@@ -107,6 +107,11 @@ export function handleVoteCast(event: VoteCast): void {
   const memberId = pluginId + '_' + member;
   let proposalId = pluginId + '_' + event.params.proposalId.toHexString();
   let voterVoteId = member + '_' + proposalId;
+  let voteOption = VOTER_OPTIONS.get(event.params.voteOption);
+
+  if (voteOption === 'None') {
+    return;
+  }
 
   let voterProposalVoteEntity = AddresslistVotingVote.load(voterVoteId);
   if (!voterProposalVoteEntity) {
@@ -114,9 +119,7 @@ export function handleVoteCast(event: VoteCast): void {
     voterProposalVoteEntity.voter = memberId;
     voterProposalVoteEntity.proposal = proposalId;
   }
-  voterProposalVoteEntity.voteOption = VOTER_OPTIONS.get(
-    event.params.voteOption
-  );
+  voterProposalVoteEntity.voteOption = voteOption;
   voterProposalVoteEntity.votingPower = event.params.votingPower;
   voterProposalVoteEntity.createdAt = event.block.timestamp;
   voterProposalVoteEntity.save();

--- a/packages/subgraph/src/packages/token/token-voting.ts
+++ b/packages/subgraph/src/packages/token/token-voting.ts
@@ -107,6 +107,11 @@ export function handleVoteCast(event: VoteCast): void {
   let memberId = pluginId + '_' + member;
   let proposalId = pluginId + '_' + event.params.proposalId.toHexString();
   let voterVoteId = member + '_' + proposalId;
+  let voteOption = VOTER_OPTIONS.get(event.params.voteOption);
+
+  if (voteOption === 'None') {
+    return;
+  }
 
   let voterProposalVoteEntity = TokenVotingVote.load(voterVoteId);
   if (!voterProposalVoteEntity) {
@@ -114,9 +119,7 @@ export function handleVoteCast(event: VoteCast): void {
     voterProposalVoteEntity.voter = memberId;
     voterProposalVoteEntity.proposal = proposalId;
   }
-  voterProposalVoteEntity.voteOption = VOTER_OPTIONS.get(
-    event.params.voteOption
-  );
+  voterProposalVoteEntity.voteOption = voteOption;
   voterProposalVoteEntity.votingPower = event.params.votingPower;
   voterProposalVoteEntity.createdAt = event.block.timestamp;
   voterProposalVoteEntity.save();

--- a/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
+++ b/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
@@ -355,7 +355,7 @@ test('Run AddresslistVoting (handleVoteCast) mappings with mock event and vote o
   let event = createNewVoteCastEvent(
     PROPOSAL_ID,
     ADDRESS_ONE,
-    '0', // yes
+    '0', // none
     '1', // votingPower
     CONTRACT_ADDRESS
   );

--- a/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
+++ b/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
@@ -323,6 +323,52 @@ test('Run AddresslistVoting (handleVoteCast) mappings with mock event', () => {
   clearStore();
 });
 
+test('Run AddresslistVoting (handleVoteCast) mappings with mock event and vote option "None"', () => {
+  // create state
+  let proposal = createAddresslistVotingProposalEntityState();
+
+  // create calls
+  createGetProposalCall(
+    CONTRACT_ADDRESS,
+    PROPOSAL_ID,
+    true,
+    false,
+
+    // ProposalParameters
+    VOTING_MODE,
+    SUPPORT_THRESHOLD,
+    MIN_PARTICIPATION,
+    START_DATE,
+    END_DATE,
+    SNAPSHOT_BLOCK,
+
+    // Tally
+    '0', // abstain
+    '0', // yes
+    '0', // no
+    TOTAL_VOTING_POWER,
+
+    actions
+  );
+
+  // create event
+  let event = createNewVoteCastEvent(
+    PROPOSAL_ID,
+    ADDRESS_ONE,
+    '0', // yes
+    '1', // votingPower
+    CONTRACT_ADDRESS
+  );
+
+  handleVoteCast(event);
+
+  // checks
+  let entityID = ADDRESS_ONE + '_' + proposal.id;
+  assert.notInStore('AddresslistVotingVote', entityID);
+  
+  clearStore();
+});
+
 test('Run AddresslistVoting (handleProposalExecuted) mappings with mock event', () => {
   // create state
   let entityID =

--- a/packages/subgraph/tests/token-voting/token-voting.test.ts
+++ b/packages/subgraph/tests/token-voting/token-voting.test.ts
@@ -313,7 +313,7 @@ test('Run TokenVoting (handleVoteCast) mappings with mock event and vote option 
   let event = createNewVoteCastEvent(
     PROPOSAL_ID,
     ADDRESS_ONE,
-    '0', // yes
+    '0', // none
     '1', // votingPower
     CONTRACT_ADDRESS
   );

--- a/packages/subgraph/tests/token-voting/token-voting.test.ts
+++ b/packages/subgraph/tests/token-voting/token-voting.test.ts
@@ -281,6 +281,52 @@ test('Run TokenVoting (handleVoteCast) mappings with mock event', () => {
   clearStore();
 });
 
+test('Run TokenVoting (handleVoteCast) mappings with mock event and vote option "None"', () => {
+  // create state
+  let proposal = createTokenVotingProposalEntityState();
+
+  // create calls
+  createGetProposalCall(
+    CONTRACT_ADDRESS,
+    PROPOSAL_ID,
+    true,
+    false,
+
+    // ProposalParameters
+    VOTING_MODE,
+    SUPPORT_THRESHOLD,
+    MIN_PARTICIPATION,
+    START_DATE,
+    END_DATE,
+    SNAPSHOT_BLOCK,
+
+    // Tally
+    '0', // abstain
+    '0', // yes
+    '0', // no
+    TOTAL_VOTING_POWER,
+
+    actions
+  );
+
+  // create event
+  let event = createNewVoteCastEvent(
+    PROPOSAL_ID,
+    ADDRESS_ONE,
+    '0', // yes
+    '1', // votingPower
+    CONTRACT_ADDRESS
+  );
+
+  handleVoteCast(event);
+
+  // checks
+  let entityID = ADDRESS_ONE + '_' + proposal.id;
+  assert.notInStore('TokenVotingVoter', entityID);
+  
+  clearStore();
+});
+
 test('Run TokenVoting (handleProposalExecuted) mappings with mock event', () => {
   // create state
   let entityID =


### PR DESCRIPTION
## Description

If a None vote gets emitted by either TokenVoting or AddresslistVoting the subgraph shouldn't store that vote, because it isn't actual any vote and thus it shouldn't influence the subgraph

Task: APP-1498

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.

[APP-1498]: https://aragonassociation.atlassian.net/browse/APP-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ