### PR TITLE
App 1452 core proposal id defined as bytes 32 on all plugins 2

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UPCOMING]
+### Changed
+- changes `proposalId` from type `uint256` to `bytes32` in Admin, TokenVoting, AddresslistVoting and MajorityVotingBase
+- changes `callId` from type `uint256` to `bytes32` in `DAO.execute(...)`
 
 ## v0.4.0-alpha
 

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -155,7 +155,7 @@ contract DAO is
     }
 
     /// @inheritdoc IDAO
-    function execute(uint256 callId, Action[] calldata _actions)
+    function execute(bytes32 callId, Action[] calldata _actions)
         external
         override
         auth(address(this), EXECUTE_PERMISSION_ID)

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -38,7 +38,7 @@ abstract contract IDAO {
     /// @param callId The id of the call. The definition of the value of callId is up to the calling contract and can be used, e.g., as a nonce.
     /// @param _actions The array of actions.
     /// @return bytes[] The array of results obtained from the executed actions in `bytes`.
-    function execute(uint256 callId, Action[] memory _actions)
+    function execute(bytes32 callId, Action[] memory _actions)
         external
         virtual
         returns (bytes[] memory);
@@ -50,7 +50,7 @@ abstract contract IDAO {
     ///      A `Plugin` implementation can use it, for example, as a nonce.
     /// @param actions Array of actions executed.
     /// @param execResults Array with the results of the executed actions.
-    event Executed(address indexed actor, uint256 callId, Action[] actions, bytes[] execResults);
+    event Executed(address indexed actor, bytes32 callId, Action[] actions, bytes[] execResults);
 
     /// @notice Emitted when a standard callback is registered.
     /// @param interfaceId The ID of the interface.

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -50,7 +50,7 @@ abstract contract IDAO {
     ///      A `Plugin` implementation can use it, for example, as a nonce.
     /// @param actions Array of actions executed.
     /// @param execResults Array with the results of the executed actions.
-    event Executed(address indexed actor, bytes32 callId, Action[] actions, bytes[] execResults);
+    event Executed(address indexed actor, bytes32 indexed callId, Action[] actions, bytes[] execResults);
 
     /// @notice Emitted when a standard callback is registered.
     /// @param interfaceId The ID of the interface.

--- a/packages/contracts/contracts/test/DAOMock.sol
+++ b/packages/contracts/contracts/test/DAOMock.sol
@@ -36,7 +36,7 @@ contract DAOMock is IDAO, PermissionManager {
         bytes calldata /* _metadata */
     ) external override {}
 
-    function execute(uint256 callId, Action[] memory _actions)
+    function execute(bytes32 callId, Action[] memory _actions)
         external
         override
         returns (bytes[] memory)

--- a/packages/contracts/contracts/test/MajorityVotingMock.sol
+++ b/packages/contracts/contracts/test/MajorityVotingMock.sol
@@ -16,19 +16,19 @@ contract MajorityVotingMock is MajorityVotingBase {
         uint64, /* _endDate */
         VoteOption, /* _voteOption */
         bool /* _tryEarlyExecution */
-    ) external pure override returns (uint256 proposalId) {
-        return 0;
+    ) external view override returns (bytes32 proposalId) {
+        return bytes32(bytes20(address(this))) | bytes32(0);
     }
 
     function _vote(
-        uint256, /* _proposalId */
+        bytes32, /* _proposalId */
         VoteOption, /* _voteOption */
         address, /* _voter */
         bool /* _tryEarlyExecution */
     ) internal pure override {}
 
     function _canVote(
-        uint256, /* _proposalId */
+        bytes32, /* _proposalId */
         address /* _voter */
     ) internal pure override returns (bool) {
         return true;

--- a/packages/contracts/contracts/voting/addresslist/AddresslistVoting.sol
+++ b/packages/contracts/contracts/voting/addresslist/AddresslistVoting.sol
@@ -81,7 +81,7 @@ contract AddresslistVoting is Addresslist, MajorityVotingBase {
         uint64 _endDate,
         VoteOption _voteOption,
         bool _tryEarlyExecution
-    ) external override returns (uint256 proposalId) {
+    ) external override returns (bytes32 proposalId_) {
         uint64 snapshotBlock;
         unchecked {
             snapshotBlock = block.number.toUint64() - 1;
@@ -91,10 +91,10 @@ contract AddresslistVoting is Addresslist, MajorityVotingBase {
             revert ProposalCreationForbidden(_msgSender());
         }
 
-        proposalId = proposalCount();
+        proposalId_ = proposalId(proposalCount());
 
         // Store proposal related information
-        Proposal storage proposal_ = proposals[proposalId];
+        Proposal storage proposal_ = proposals[proposalId_];
 
         (proposal_.parameters.startDate, proposal_.parameters.endDate) = _validateProposalDates(
             _startDate,
@@ -117,11 +117,11 @@ contract AddresslistVoting is Addresslist, MajorityVotingBase {
         _incrementProposalCount();
 
         if (_voteOption != VoteOption.None) {
-            vote(proposalId, _voteOption, _tryEarlyExecution);
+            vote(proposalId_, _voteOption, _tryEarlyExecution);
         }
 
         emit ProposalCreated({
-            proposalId: proposalId,
+            proposalId: proposalId_,
             creator: _msgSender(),
             metadata: _metadata,
             actions: _actions
@@ -130,7 +130,7 @@ contract AddresslistVoting is Addresslist, MajorityVotingBase {
 
     /// @inheritdoc MajorityVotingBase
     function _vote(
-        uint256 _proposalId,
+        bytes32 _proposalId,
         VoteOption _voteOption,
         address _voter,
         bool _tryEarlyExecution
@@ -172,7 +172,7 @@ contract AddresslistVoting is Addresslist, MajorityVotingBase {
     }
 
     /// @inheritdoc MajorityVotingBase
-    function _canVote(uint256 _proposalId, address _account) internal view override returns (bool) {
+    function _canVote(bytes32 _proposalId, address _account) internal view override returns (bool) {
         Proposal storage proposal_ = proposals[_proposalId];
 
         // The proposal vote hasn't started or has already ended.

--- a/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
+++ b/packages/contracts/contracts/voting/majority/IMajorityVoting.sol
@@ -61,7 +61,7 @@ interface IMajorityVoting {
     /// @param voteOption The vote option chosen.
     /// @param votingPower The voting power behind this vote.
     event VoteCast(
-        uint256 indexed proposalId,
+        bytes32 indexed proposalId,
         address indexed voter,
         VoteOption voteOption,
         uint256 votingPower
@@ -78,21 +78,25 @@ interface IMajorityVoting {
     /// @notice Returns the support value defined as $$\texttt{support} = \frac{N_\text{yes}}{N_\text{yes}+N_\text{no}}$$ for a proposal vote.
     /// @param _proposalId The ID of the proposal.
     /// @return The support value.
-    function support(uint256 _proposalId) external view returns (uint256);
+    function support(bytes32 _proposalId) external view returns (uint256);
 
     /// @notice Returns the worst case support value defined as $$\texttt{worstCaseSupport} = \frac{N_\text{yes}}{ N_\text{total}-N_\text{abstain}}$$ for a proposal vote.
     /// @param _proposalId The ID of the proposal.
     /// @return The worst case support value.
-    function worstCaseSupport(uint256 _proposalId) external view returns (uint256);
+    function worstCaseSupport(bytes32 _proposalId) external view returns (uint256);
 
     /// @notice Returns the participation value defined as $$\texttt{participation} = \frac{N_\text{yes}+N_\text{no}+N_\text{abstain}}{N_\text{total}}$$ for a proposal vote.
     /// @param _proposalId The ID of the proposal.
     /// @return The participation value.
-    function participation(uint256 _proposalId) external view returns (uint256);
+    function participation(bytes32 _proposalId) external view returns (uint256);
 
     /// @notice Returns the proposal count determining the next proposal ID.
     /// @return The proposal count.
     function proposalCount() external view returns (uint256);
+
+    /// @notice Returns the proposalId for a given proposal count
+    /// return The proposalId
+    function proposalId(uint256 _proposalCount) external view returns (bytes32);
 
     /// @notice Checks if an account can participate on a proposal vote. This can be because the vote
     /// - has not started,
@@ -103,12 +107,12 @@ interface IMajorityVoting {
     /// @param _account The account address to be checked.
     /// @return bool Returns true if the account is allowed to vote.
     /// @dev The function assumes the queried proposal exists.
-    function canVote(uint256 _proposalId, address _account) external view returns (bool);
+    function canVote(bytes32 _proposalId, address _account) external view returns (bool);
 
     /// @notice Checks if a proposal can be executed.
     /// @param _proposalId The ID of the proposal to be checked.
     /// @return True if the proposal can be executed, false otherwise.
-    function canExecute(uint256 _proposalId) external view returns (bool);
+    function canExecute(bytes32 _proposalId) external view returns (bool);
 
     /// @notice Votes for a vote option and, optionally, executes the proposal.
     /// @dev `_voteOption`, 1 -> abstain, 2 -> yes, 3 -> no
@@ -116,20 +120,20 @@ interface IMajorityVoting {
     /// @param  _voteOption Whether voter abstains, supports or not supports to vote.
     /// @param _tryEarlyExecution If `true`,  early execution is tried after the vote cast. The call does not revert if early execution is not possible.
     function vote(
-        uint256 _proposalId,
+        bytes32 _proposalId,
         VoteOption _voteOption,
         bool _tryEarlyExecution
     ) external;
 
     /// @notice Executes a proposal.
     /// @param _proposalId The ID of the proposal to be executed.
-    function execute(uint256 _proposalId) external;
+    function execute(bytes32 _proposalId) external;
 
     /// @notice Returns whether the account has voted for the proposal.  Note, that this does not check if the account has voting power.
     /// @param _proposalId The ID of the proposal.
     /// @param _account The account address to be checked.
     /// @return The vote option cast by a voter for a certain proposal.
-    function getVoteOption(uint256 _proposalId, address _account)
+    function getVoteOption(bytes32 _proposalId, address _account)
         external
         view
         returns (VoteOption);

--- a/packages/contracts/contracts/voting/multisig/Multisig.sol
+++ b/packages/contracts/contracts/voting/multisig/Multisig.sol
@@ -114,7 +114,7 @@ contract Multisig is PluginUUPSUpgradeable, Addresslist {
     /// @param metadata The metadata of the proposal.
     /// @param actions The actions that will be executed if the proposal passes.
     event ProposalCreated(
-        bytes32 proposalId,
+        bytes32 indexed proposalId,
         address indexed creator,
         bytes metadata,
         IDAO.Action[] actions
@@ -123,7 +123,7 @@ contract Multisig is PluginUUPSUpgradeable, Addresslist {
     /// @notice Emitted when a proposal is executed.
     /// @param proposalId The ID of the proposal.
     /// @param execResults The bytes array resulting from the proposal execution in the associated DAO.
-    event ProposalExecuted(bytes32 proposalId, bytes[] execResults);
+    event ProposalExecuted(bytes32 indexed proposalId, bytes[] execResults);
 
     /// @notice Emitted when the plugin settings are set.
     /// @param onlyListed Whether only listed addresses can create a proposal.

--- a/packages/contracts/contracts/voting/multisig/Multisig.sol
+++ b/packages/contracts/contracts/voting/multisig/Multisig.sol
@@ -297,7 +297,7 @@ contract Multisig is PluginUUPSUpgradeable, Addresslist {
     /// @param _account The address of the user to check.
     /// @return bool Returns true if the account is allowed to vote.
     /// @dev The function assumes the queried proposal exists.
-    function canApprove(uint256 _proposalId, address _account) external view returns (bool) {
+    function canApprove(bytes32 _proposalId, address _account) external view returns (bool) {
         return _canApprove(_proposalId, _account);
     }
 

--- a/packages/contracts/contracts/voting/token/TokenVoting.sol
+++ b/packages/contracts/contracts/voting/token/TokenVoting.sol
@@ -63,7 +63,7 @@ contract TokenVoting is MajorityVotingBase {
         uint64 _endDate,
         VoteOption _voteOption,
         bool _tryEarlyExecution
-    ) external override returns (uint256 proposalId) {
+    ) external override returns (bytes32 proposalId_) {
         uint64 snapshotBlock = block.number.toUint64() - 1;
 
         uint256 totalVotingPower = votingToken.getPastTotalSupply(snapshotBlock);
@@ -73,10 +73,10 @@ contract TokenVoting is MajorityVotingBase {
             revert ProposalCreationForbidden(_msgSender());
         }
 
-        proposalId = proposalCount();
+        proposalId_ = proposalId(proposalCount());
 
         // Store proposal related information
-        Proposal storage proposal_ = proposals[proposalId];
+        Proposal storage proposal_ = proposals[proposalId_];
 
         (proposal_.parameters.startDate, proposal_.parameters.endDate) = _validateProposalDates(
             _startDate,
@@ -99,11 +99,11 @@ contract TokenVoting is MajorityVotingBase {
         _incrementProposalCount();
 
         if (_voteOption != VoteOption.None) {
-            vote(proposalId, _voteOption, _tryEarlyExecution);
+            vote(proposalId_, _voteOption, _tryEarlyExecution);
         }
 
         emit ProposalCreated({
-            proposalId: proposalId,
+            proposalId: proposalId_,
             creator: _msgSender(),
             metadata: _metadata,
             actions: _actions
@@ -112,7 +112,7 @@ contract TokenVoting is MajorityVotingBase {
 
     /// @inheritdoc MajorityVotingBase
     function _vote(
-        uint256 _proposalId,
+        bytes32 _proposalId,
         VoteOption _voteOption,
         address _voter,
         bool _tryEarlyExecution
@@ -156,7 +156,7 @@ contract TokenVoting is MajorityVotingBase {
     }
 
     /// @inheritdoc MajorityVotingBase
-    function _canVote(uint256 _proposalId, address _account) internal view override returns (bool) {
+    function _canVote(bytes32 _proposalId, address _account) internal view override returns (bool) {
         Proposal storage proposal_ = proposals[_proposalId];
 
         // The proposal vote hasn't started or has already ended.

--- a/packages/contracts/test/core/dao.ts
+++ b/packages/contracts/test/core/dao.ts
@@ -197,7 +197,12 @@ describe('DAO', function () {
         PERMISSION_IDS.EXECUTE_PERMISSION_ID
       );
 
-      await expect(dao.execute(0, dummyActions)).to.be.revertedWith(
+      await expect(
+        dao.execute(
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          dummyActions
+        )
+      ).to.be.revertedWith(
         customError(
           'Unauthorized',
           dao.address,
@@ -209,19 +214,27 @@ describe('DAO', function () {
     });
 
     it('executes an array of actions', async () => {
-      expect(await dao.callStatic.execute(0, dummyActions)).to.deep.equal(
-        expectedDummyResults
-      );
+      expect(
+        await dao.callStatic.execute(
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          dummyActions
+        )
+      ).to.deep.equal(expectedDummyResults);
     });
 
     it('emits an event afterwards', async () => {
-      let tx = await dao.execute(0, dummyActions);
+      let tx = await dao.execute(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        dummyActions
+      );
       let rc = await tx.wait();
 
       const event = await findEvent(tx, DAO_EVENTS.EXECUTED);
 
       expect(event.args.actor).to.equal(ownerAddress);
-      expect(event.args.callId).to.equal(0);
+      expect(event.args.callId).to.equal(
+        '0x0000000000000000000000000000000000000000000000000000000000000000'
+      );
       expect(event.args.actions.length).to.equal(1);
       expect(event.args.actions[0].to).to.equal(dummyActions[0].to);
       expect(event.args.actions[0].value).to.equal(dummyActions[0].value);
@@ -234,13 +247,16 @@ describe('DAO', function () {
       const actionExecute = await ActionExecuteFactory.deploy();
 
       await expect(
-        dao.execute(0, [
-          {
-            to: actionExecute.address,
-            data: '0x0000',
-            value: 0,
-          },
-        ])
+        dao.execute(
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          [
+            {
+              to: actionExecute.address,
+              data: '0x0000',
+              value: 0,
+            },
+          ]
+        )
       ).to.be.revertedWith(customError('ActionFailed'));
     });
   });

--- a/packages/contracts/test/test-utils/voting.ts
+++ b/packages/contracts/test/test-utils/voting.ts
@@ -57,3 +57,11 @@ export async function advanceAfterVoteEnd(endDate: number) {
   await advanceTimeTo(endDate);
   expect(await getTime()).to.be.greaterThanOrEqual(endDate);
 }
+
+// proposalNumber has to be in hex
+export function getProposalId(address: string, proposalNumber: string) {
+  proposalNumber = proposalNumber.replace('0x', '');
+  return `${address.toLowerCase()}${'0'.repeat(
+    24 - proposalNumber.length
+  )}${proposalNumber.toLowerCase()}`;
+}

--- a/packages/contracts/test/voting/addresslist-voting.ts
+++ b/packages/contracts/test/voting/addresslist-voting.ts
@@ -20,6 +20,7 @@ import {
   VotingMode,
   ONE_HOUR,
   MAX_UINT64,
+  getProposalId,
 } from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
@@ -32,9 +33,9 @@ describe('AddresslistVoting', function () {
   let startDate: number;
   let endDate: number;
   let votingSettings: VotingSettings;
+  let id: string;
 
   const startOffset = 10;
-  const id = 0;
 
   let mergedAbi: any;
   let addresslistVotingFactoryBytecode: any;
@@ -85,6 +86,7 @@ describe('AddresslistVoting', function () {
       signers[0]
     );
     voting = await AddresslistVotingFactory.deploy();
+    id = getProposalId(voting.address, '0x0');
 
     startDate = (await getTime()) + startOffset;
     endDate = startDate + votingSettings.minDuration;
@@ -329,7 +331,12 @@ describe('AddresslistVoting', function () {
 
       expect(await voting.canVote(id, signers[0].address)).to.equal(true);
       expect(await voting.canVote(id, signers[1].address)).to.equal(false);
-      expect(await voting.canVote(1, signers[0].address)).to.equal(false);
+      expect(
+        await voting.canVote(
+          getProposalId(voting.address, '0x1'),
+          signers[0].address
+        )
+      ).to.equal(false);
 
       expect(proposal.actions.length).to.equal(1);
       expect(proposal.actions[0].to).to.equal(dummyActions[0].to);
@@ -399,18 +406,14 @@ describe('AddresslistVoting', function () {
       );
 
       // Works if the vote option is 'None'
-      expect(
-        (
-          await voting.createProposal(
-            dummyMetadata,
-            dummyActions,
-            startDate,
-            endDate,
-            VoteOption.None,
-            false
-          )
-        ).value
-      ).to.equal(id);
+      await voting.createProposal(
+        dummyMetadata,
+        dummyActions,
+        startDate,
+        endDate,
+        VoteOption.None,
+        false
+      );
     });
   });
 
@@ -421,18 +424,14 @@ describe('AddresslistVoting', function () {
 
         await voting.initialize(dao.address, votingSettings, addresslist(10));
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('reverts on vote replacement', async () => {
@@ -558,18 +557,14 @@ describe('AddresslistVoting', function () {
 
         await voting.initialize(dao.address, votingSettings, addresslist(10));
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('does not allow voting, when the vote has not started yet', async () => {
@@ -756,18 +751,14 @@ describe('AddresslistVoting', function () {
 
         await voting.initialize(dao.address, votingSettings, addresslist(10));
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('should allow vote replacement but not double-count votes by the same address', async () => {
@@ -1032,18 +1023,15 @@ describe('AddresslistVoting', function () {
         votingSettings.minParticipation = pct16(75);
 
         await voting.initialize(dao.address, votingSettings, addresslist(10));
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('does not execute if support is high enough but participation is too low', async () => {

--- a/packages/contracts/test/voting/admin.ts
+++ b/packages/contracts/test/voting/admin.ts
@@ -8,6 +8,7 @@ import {findEvent, PROPOSAL_EVENTS} from '../../utils/event';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 import {getInterfaceID} from '../test-utils/interfaces';
 import {BigNumber} from 'ethers';
+import {getProposalId} from '../test-utils/voting';
 
 chai.use(smock.matchers);
 
@@ -153,7 +154,7 @@ describe('Admin plugin', function () {
     });
 
     it('correctly emits the ProposalCreated event', async () => {
-      const currentExpectedProposalId = 0;
+      const currentExpectedProposalId = getProposalId(plugin.address, '0x0');
 
       const tx = await plugin.executeProposal(dummyMetadata, dummyActions);
 
@@ -171,7 +172,7 @@ describe('Admin plugin', function () {
     });
 
     it('correctly emits the `ProposalExecuted` event', async () => {
-      const currentExpectedProposalId = 0;
+      const currentExpectedProposalId = getProposalId(plugin.address, '0x0');
       const expectedDummyResults = ['0x'];
 
       await expect(plugin.executeProposal(dummyMetadata, dummyActions))
@@ -180,11 +181,9 @@ describe('Admin plugin', function () {
     });
 
     it('correctly increments the proposal ID', async () => {
-      const currentExpectedProposalId = 0;
-
       await plugin.executeProposal(dummyMetadata, dummyActions);
 
-      const nextExpectedProposalId = currentExpectedProposalId + 1;
+      const nextExpectedProposalId = getProposalId(plugin.address, '0x1');
 
       const tx = await plugin.executeProposal(dummyMetadata, dummyActions);
 
@@ -196,7 +195,7 @@ describe('Admin plugin', function () {
     });
 
     it("calls the DAO's execute function correctly", async () => {
-      const proposalId = 1;
+      const proposalId = getProposalId(plugin.address, '0x1');
 
       await plugin.executeProposal(dummyMetadata, dummyActions);
 

--- a/packages/contracts/test/voting/admin.ts
+++ b/packages/contracts/test/voting/admin.ts
@@ -195,11 +195,11 @@ describe('Admin plugin', function () {
     });
 
     it("calls the DAO's execute function correctly", async () => {
-      const proposalId = getProposalId(plugin.address, '0x1');
+      const proposalId = getProposalId(plugin.address, '0x0');
 
       await plugin.executeProposal(dummyMetadata, dummyActions);
 
-      expect(dao.execute).has.been.calledWith(BigNumber.from(proposalId), [
+      expect(dao.execute).has.been.calledWith(proposalId, [
         [
           dummyActions[0].to,
           BigNumber.from(dummyActions[0].value),

--- a/packages/contracts/test/voting/multisig.ts
+++ b/packages/contracts/test/voting/multisig.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/event';
 import {getMergedABI} from '../../utils/abi';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
+import {getProposalId} from '../test-utils/voting';
 
 export type MultisigSettings = {
   minApprovals: number;
@@ -295,8 +296,8 @@ describe('Multisig', function () {
         false
       );
 
-      expect(proposalId0).to.equal(0); // To be removed when proposal ID is generated as a hash.
-      expect(proposalId1).to.equal(1); // To be removed when proposal ID is generated as a hash.
+      expect(proposalId0).to.equal(getProposalId(multisig.address, '0x0')); // To be removed when proposal ID is generated as a hash.
+      expect(proposalId1).to.equal(getProposalId(multisig.address, '0x1')); // To be removed when proposal ID is generated as a hash.
 
       expect(proposalId0).to.not.equal(proposalId1);
     });

--- a/packages/contracts/test/voting/multisig.ts
+++ b/packages/contracts/test/voting/multisig.ts
@@ -25,7 +25,7 @@ describe('Multisig', function () {
   let dummyMetadata: string;
   let multisigSettings: MultisigSettings;
 
-  const id = 0;
+  let id: string;
 
   let mergedAbi: any;
   let multisigFactoryBytecode: any;
@@ -72,6 +72,7 @@ describe('Multisig', function () {
       signers[0]
     );
     multisig = await MultisigFactory.deploy();
+    id = getProposalId(multisig.address, '0x0');
 
     dao.grant(
       dao.address,
@@ -422,16 +423,7 @@ describe('Multisig', function () {
       multisigSettings.minApprovals = 3;
       await multisig.initialize(dao.address, addresslist(5), multisigSettings);
 
-      expect(
-        (
-          await multisig.createProposal(
-            dummyMetadata,
-            dummyActions,
-            false,
-            false
-          )
-        ).value
-      ).to.equal(id);
+      await multisig.createProposal(dummyMetadata, dummyActions, false, false);
     });
 
     describe('canApprove:', async () => {

--- a/packages/contracts/test/voting/token-voting.ts
+++ b/packages/contracts/test/voting/token-voting.ts
@@ -21,6 +21,7 @@ import {
   VotingMode,
   ONE_HOUR,
   MAX_UINT64,
+  getProposalId,
 } from '../test-utils/voting';
 import {customError, ERRORS} from '../test-utils/custom-error-helper';
 
@@ -36,9 +37,9 @@ describe('TokenVoting', function () {
   let startDate: number;
   let endDate: number;
   let votingSettings: VotingSettings;
+  let id: string;
 
   const startOffset = 10;
-  const id = 0;
   const totalVotingPower = 100;
 
   let mergedAbi: any;
@@ -97,6 +98,7 @@ describe('TokenVoting', function () {
     );
     voting = await TokenVotingFactory.deploy();
 
+    id = getProposalId(voting.address, '0x0');
     startDate = (await getTime()) + startOffset;
     endDate = startDate + votingSettings.minDuration;
 
@@ -303,7 +305,7 @@ describe('TokenVoting', function () {
       );
     });
 
-    it('should create a vote successfully, but not vote', async () => {
+    it('should create a proposal successfully, but not vote', async () => {
       await voting.initialize(
         dao.address,
         votingSettings,
@@ -356,7 +358,7 @@ describe('TokenVoting', function () {
       expect(proposal.tally.yes).to.equal(0);
       expect(proposal.tally.no).to.equal(0);
 
-      expect(await voting.canVote(1, signers[0].address)).to.equal(false);
+      expect(await voting.canVote(getProposalId(voting.address, '0x1'), signers[0].address)).to.equal(false);
 
       expect(proposal.actions.length).to.equal(1);
       expect(proposal.actions[0].to).to.equal(dummyActions[0].to);
@@ -445,20 +447,6 @@ describe('TokenVoting', function () {
       ).to.be.revertedWith(
         customError('VoteCastForbidden', id, signers[0].address)
       );
-
-      // Works if the vote option is 'None'
-      expect(
-        (
-          await voting.createProposal(
-            dummyMetadata,
-            dummyActions,
-            startDate,
-            endDate,
-            VoteOption.None,
-            false
-          )
-        ).value
-      ).to.equal(id);
     });
   });
 
@@ -479,18 +467,14 @@ describe('TokenVoting', function () {
         );
         await governanceErc20Mock.mock.getPastVotes.returns(1);
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('reverts on vote replacement', async () => {
@@ -620,18 +604,14 @@ describe('TokenVoting', function () {
         );
         await governanceErc20Mock.mock.getPastVotes.returns(1);
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('does not allow voting, when the vote has not started yet', async () => {
@@ -867,18 +847,14 @@ describe('TokenVoting', function () {
         );
         await governanceErc20Mock.mock.getPastVotes.returns(1);
 
-        expect(
-          (
-            await voting.createProposal(
-              dummyMetadata,
-              dummyActions,
-              startDate,
-              endDate,
-              VoteOption.None,
-              false
-            )
-          ).value
-        ).to.equal(id);
+        await voting.createProposal(
+          dummyMetadata,
+          dummyActions,
+          startDate,
+          endDate,
+          VoteOption.None,
+          false
+        );
       });
 
       it('should allow vote replacement but not double-count votes by the same address', async () => {

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Ignores `None` votes from addresslist voting and token voting
+- Changes proposal ID to be used directly from the event (contracts generate them now uniquely per contract)
+- Action ids consist now of `proposalID + action index`
+
+### Removed
+- Removes `proposalId` field from proposals because the `id` field is used
 
 ## 0.5.0-alpha
 

--- a/packages/subgraph/manifest/subgraph.placeholder.yaml
+++ b/packages/subgraph/manifest/subgraph.placeholder.yaml
@@ -120,7 +120,7 @@ templates:
           handler: handleDeposited
         - event: NativeTokenDeposited(address,uint256)
           handler: handleNativeTokenDeposited
-        - event: Executed(indexed address,uint256,(address,uint256,bytes)[],bytes[])
+        - event: Executed(indexed address,indexed bytes32,(address,uint256,bytes)[],bytes[])
           handler: handleExecuted
         - event: Granted(indexed bytes32,indexed address,address,indexed address,address)
           handler: handleGranted
@@ -153,11 +153,11 @@ templates:
         - name: TokenVoting
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/voting/token/TokenVoting.sol/TokenVoting.json
       eventHandlers:
-        - event: VoteCast(indexed uint256,indexed address,uint8,uint256)
+        - event: VoteCast(indexed bytes32,indexed address,uint8,uint256)
           handler: handleVoteCast
-        - event: ProposalExecuted(indexed uint256,bytes[])
+        - event: ProposalExecuted(indexed bytes32,bytes[])
           handler: handleProposalExecuted
-        - event: ProposalCreated(indexed uint256,indexed address,bytes,(address,uint256,bytes)[])
+        - event: ProposalCreated(indexed bytes32,indexed address,bytes,(address,uint256,bytes)[])
           handler: handleProposalCreated
         - event: VotingSettingsUpdated(uint8,uint64,uint64,uint64,uint256)
           handler: handleVotingSettingsUpdated
@@ -178,11 +178,11 @@ templates:
         - name: AddresslistVoting
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/voting/addresslist/AddresslistVoting.sol/AddresslistVoting.json
       eventHandlers:
-        - event: VoteCast(indexed uint256,indexed address,uint8,uint256)
+        - event: VoteCast(indexed bytes32,indexed address,uint8,uint256)
           handler: handleVoteCast
-        - event: ProposalExecuted(indexed uint256,bytes[])
+        - event: ProposalExecuted(indexed bytes32,bytes[])
           handler: handleProposalExecuted
-        - event: ProposalCreated(indexed uint256,indexed address,bytes,(address,uint256,bytes)[])
+        - event: ProposalCreated(indexed bytes32,indexed address,bytes,(address,uint256,bytes)[])
           handler: handleProposalCreated
         - event: VotingSettingsUpdated(uint8,uint64,uint64,uint64,uint256)
           handler: handleVotingSettingsUpdated
@@ -211,11 +211,11 @@ templates:
           handler: handleAddressesAdded
         - event: AddressesRemoved(address[])
           handler: handleAddressesRemoved
-        - event: Approved(indexed uint256,indexed address)
+        - event: Approved(indexed bytes32,indexed address)
           handler: handleApproved
-        - event: ProposalCreated(indexed uint256,indexed address,bytes,(address,uint256,bytes)[])
+        - event: ProposalCreated(indexed bytes32,indexed address,bytes,(address,uint256,bytes)[])
           handler: handleProposalCreated
-        - event: ProposalExecuted(indexed uint256,bytes[])
+        - event: ProposalExecuted(indexed bytes32,bytes[])
           handler: handleProposalExecuted
         - event: MultisigSettingsUpdated(bool,indexed uint256)
           handler: handleMultisigSettingsUpdated
@@ -236,9 +236,9 @@ templates:
         - name: Admin
           file: $ZARAGOZA_CONTRACTS_MODULE/artifacts/contracts/voting/admin/Admin.sol/Admin.json
       eventHandlers:
-        - event: ProposalExecuted(indexed uint256,bytes[])
+        - event: ProposalExecuted(indexed bytes32,bytes[])
           handler: handleProposalExecuted
-        - event: ProposalCreated(indexed uint256,indexed address,bytes,(address,uint256,bytes)[])
+        - event: ProposalCreated(indexed bytes32,indexed address,bytes,(address,uint256,bytes)[])
           handler: handleProposalCreated
   # PluginRepo
   - name: PluginRepoTemplate

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -178,7 +178,7 @@ interface IPlugin {
 # Proposal
 
 interface Proposal {
-  id: ID! # package + proposalId
+  id: ID! # proposalId
   dao: Dao!
   creator: Bytes!
   metadata: String
@@ -238,11 +238,10 @@ type TokenVotingVote @entity {
 }
 
 type TokenVotingProposal implements Proposal @entity {
-  id: ID! # package + proposalId
+  id: ID! # proposalId
   dao: Dao!
   actions: [Action!]! @derivedFrom(field: "proposal")
   plugin: TokenVotingPlugin!
-  proposalId: BigInt!
   creator: Bytes!
   metadata: String
 
@@ -303,11 +302,10 @@ type AddresslistVotingVote @entity {
 }
 
 type AddresslistVotingProposal implements Proposal @entity {
-  id: ID! # package + proposalId
+  id: ID! # proposalId
   dao: Dao!
   actions: [Action!]! @derivedFrom(field: "proposal")
   plugin: AddresslistVotingPlugin!
-  proposalId: BigInt!
   creator: Bytes!
   metadata: String
 
@@ -359,7 +357,7 @@ type AdminstratorAdminPlugin @entity {
 }
 
 type AdminProposal implements Proposal @entity {
-  id: ID! # plugin + proposalId
+  id: ID! # proposalId
   dao: Dao!
   creator: Bytes! # Adminstrator address
   metadata: String
@@ -367,7 +365,6 @@ type AdminProposal implements Proposal @entity {
   executed: Boolean!
   createdAt: BigInt!
   plugin: AdminPlugin!
-  proposalId: BigInt!
   adminstrator: Adminstrator!
 }
 
@@ -402,11 +399,10 @@ type MultisigProposalApprover @entity(immutable: true) {
 }
 
 type MultisigProposal implements Proposal @entity {
-  id: ID! # plugin + proposalId
+  id: ID! # proposalId
   dao: Dao!
   actions: [Action!]! @derivedFrom(field: "proposal")
   plugin: MultisigPlugin!
-  proposalId: BigInt!
   creator: Bytes!
   metadata: String
   createdAt: BigInt!

--- a/packages/subgraph/src/dao/dao.ts
+++ b/packages/subgraph/src/dao/dao.ts
@@ -152,10 +152,7 @@ export function handleExecuted(event: Executed): void {
         );
       }
 
-      let proposalId =
-        event.params.actor.toHexString() +
-        '_' +
-        event.params.callId.toHexString();
+      let proposalId = event.params.callId.toHexString();
 
       // create a withdraw entity
       let withdrawId =

--- a/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
+++ b/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
@@ -31,13 +31,10 @@ export function _handleProposalCreated(
   daoId: string,
   metadata: string
 ): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
-
+  let proposalId = event.params.proposalId.toHexString();
   let proposalEntity = new AddresslistVotingProposal(proposalId);
   proposalEntity.dao = daoId;
   proposalEntity.plugin = event.address.toHexString();
-  proposalEntity.proposalId = event.params.proposalId;
   proposalEntity.creator = event.params.creator;
   proposalEntity.metadata = metadata;
   proposalEntity.createdAt = event.block.timestamp;
@@ -72,11 +69,7 @@ export function _handleProposalCreated(
       const action = actions[index];
 
       let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+        event.params.proposalId.toHexString() + '_' + index.toString();
 
       let actionEntity = new Action(actionId);
       actionEntity.to = action.to;
@@ -105,7 +98,7 @@ export function handleVoteCast(event: VoteCast): void {
   const member = event.params.voter.toHexString();
   const pluginId = event.address.toHexString();
   const memberId = pluginId + '_' + member;
-  let proposalId = pluginId + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let voterVoteId = member + '_' + proposalId;
   let voteOption = VOTER_OPTIONS.get(event.params.voteOption);
 
@@ -170,8 +163,7 @@ export function handleVoteCast(event: VoteCast): void {
 }
 
 export function handleProposalExecuted(event: ProposalExecuted): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let proposalEntity = AddresslistVotingProposal.load(proposalId);
   if (proposalEntity) {
     proposalEntity.executed = true;
@@ -186,12 +178,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
   if (!proposal.reverted) {
     let actions = proposal.value.value4;
     for (let index = 0; index < actions.length; index++) {
-      let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+      let actionId = proposalId + '_' + index.toString();
 
       let actionEntity = Action.load(actionId);
       if (actionEntity) {

--- a/packages/subgraph/src/packages/admin/admin.ts
+++ b/packages/subgraph/src/packages/admin/admin.ts
@@ -24,17 +24,13 @@ export function _handleProposalCreated(
   daoId: string,
   metadata: string
 ): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
-
+  let proposalId = event.params.proposalId.toHexString();
   let pluginId = event.address.toHexString();
-
   let adminstratorAddress = event.params.creator;
 
   let proposalEntity = new AdminProposal(proposalId);
   proposalEntity.dao = daoId;
   proposalEntity.plugin = pluginId;
-  proposalEntity.proposalId = event.params.proposalId;
   proposalEntity.creator = adminstratorAddress;
   proposalEntity.metadata = metadata;
   proposalEntity.executed = false;
@@ -63,11 +59,7 @@ export function _handleProposalCreated(
     const action = actions[index];
 
     let actionId =
-      event.address.toHexString() +
-      '_' +
-      event.params.proposalId.toHexString() +
-      '_' +
-      index.toString();
+      event.params.proposalId.toHexString() + '_' + index.toString();
 
     let actionEntity = new Action(actionId);
     actionEntity.to = action.to;
@@ -82,8 +74,7 @@ export function _handleProposalCreated(
 }
 
 export function handleProposalExecuted(event: ProposalExecuted): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let proposalEntity = AdminProposal.load(proposalId);
   if (proposalEntity) {
     proposalEntity.executed = true;

--- a/packages/subgraph/src/packages/multisig/multisig.ts
+++ b/packages/subgraph/src/packages/multisig/multisig.ts
@@ -1,4 +1,4 @@
-import { dataSource, store } from '@graphprotocol/graph-ts';
+import {dataSource, store} from '@graphprotocol/graph-ts';
 
 import {
   ProposalCreated,
@@ -30,13 +30,11 @@ export function _handleProposalCreated(
   daoId: string,
   metadata: string
 ): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
 
   let proposalEntity = new MultisigProposal(proposalId);
   proposalEntity.dao = daoId;
   proposalEntity.plugin = event.address.toHexString();
-  proposalEntity.proposalId = event.params.proposalId;
   proposalEntity.creator = event.params.creator;
   proposalEntity.metadata = metadata;
   proposalEntity.createdAt = event.block.timestamp;
@@ -65,11 +63,7 @@ export function _handleProposalCreated(
       const action = actions[index];
 
       let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+        event.params.proposalId.toHexString() + '_' + index.toString();
 
       let actionEntity = new Action(actionId);
       actionEntity.to = action.to;
@@ -99,7 +93,7 @@ export function handleApproved(event: Approved): void {
   const pluginId = event.address.toHexString();
   const memberId = pluginId + '_' + member;
 
-  let proposalId = pluginId + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let approverProposalId = member + '_' + proposalId;
   let approverProposalEntity = MultisigProposalApprover.load(
     approverProposalId
@@ -136,8 +130,7 @@ export function handleApproved(event: Approved): void {
 }
 
 export function handleProposalExecuted(event: ProposalExecuted): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let proposalEntity = MultisigProposal.load(proposalId);
   if (proposalEntity) {
     proposalEntity.open = false;
@@ -153,12 +146,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
   if (!proposal.reverted) {
     let actions = proposal.value.value4;
     for (let index = 0; index < actions.length; index++) {
-      let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+      let actionId = proposalId + '_' + index.toString();
 
       let actionEntity = Action.load(actionId);
       if (actionEntity) {
@@ -200,7 +188,9 @@ export function handleAddressesRemoved(event: AddressesRemoved): void {
   }
 }
 
-export function handleMultisigSettingsUpdated(event: MultisigSettingsUpdated): void {
+export function handleMultisigSettingsUpdated(
+  event: MultisigSettingsUpdated
+): void {
   let packageEntity = MultisigPlugin.load(event.address.toHexString());
   if (packageEntity) {
     packageEntity.onlyListed = event.params.onlyListed;

--- a/packages/subgraph/src/packages/token/token-voting.ts
+++ b/packages/subgraph/src/packages/token/token-voting.ts
@@ -30,13 +30,11 @@ export function _handleProposalCreated(
   daoId: string,
   metadata: string
 ): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
 
   let proposalEntity = new TokenVotingProposal(proposalId);
   proposalEntity.dao = daoId;
   proposalEntity.plugin = event.address.toHexString();
-  proposalEntity.proposalId = event.params.proposalId;
   proposalEntity.creator = event.params.creator;
   proposalEntity.metadata = metadata;
   proposalEntity.createdAt = event.block.timestamp;
@@ -72,11 +70,7 @@ export function _handleProposalCreated(
       const action = actions[index];
 
       let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+        event.params.proposalId.toHexString() + '_' + index.toString();
 
       let actionEntity = new Action(actionId);
       actionEntity.to = action.to;
@@ -105,7 +99,7 @@ export function handleVoteCast(event: VoteCast): void {
   let pluginId = event.address.toHexString();
   let member = event.params.voter.toHexString();
   let memberId = pluginId + '_' + member;
-  let proposalId = pluginId + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let voterVoteId = member + '_' + proposalId;
   let voteOption = VOTER_OPTIONS.get(event.params.voteOption);
 
@@ -183,8 +177,7 @@ export function handleVoteCast(event: VoteCast): void {
 }
 
 export function handleProposalExecuted(event: ProposalExecuted): void {
-  let proposalId =
-    event.address.toHexString() + '_' + event.params.proposalId.toHexString();
+  let proposalId = event.params.proposalId.toHexString();
   let proposalEntity = TokenVotingProposal.load(proposalId);
   if (proposalEntity) {
     proposalEntity.executed = true;
@@ -200,11 +193,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
     let actions = proposal.value.value4;
     for (let index = 0; index < actions.length; index++) {
       let actionId =
-        event.address.toHexString() +
-        '_' +
-        event.params.proposalId.toHexString() +
-        '_' +
-        index.toString();
+        event.params.proposalId.toHexString() + '_' + index.toString();
 
       let actionEntity = Action.load(actionId);
       if (actionEntity) {

--- a/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
+++ b/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
@@ -44,7 +44,6 @@ import {
   createAddresslistVotingProposalEntityState
 } from './utils';
 
-let proposalId = '0';
 let actions = createDummyActions(DAO_TOKEN_ADDRESS, '0', '0x00000000');
 
 test('Run AddresslistVoting (handleProposalCreated) mappings with mock event', () => {
@@ -58,7 +57,7 @@ test('Run AddresslistVoting (handleProposalCreated) mappings with mock event', (
   getProposalCountCall(CONTRACT_ADDRESS, '1');
   createGetProposalCall(
     CONTRACT_ADDRESS,
-    proposalId,
+    PROPOSAL_ID,
     true,
     false,
 
@@ -81,7 +80,7 @@ test('Run AddresslistVoting (handleProposalCreated) mappings with mock event', (
 
   // create event
   let event = createNewProposalCreatedEvent(
-    proposalId,
+    PROPOSAL_ID,
     ADDRESS_ONE,
     STRING_DATA,
     CONTRACT_ADDRESS
@@ -90,105 +89,95 @@ test('Run AddresslistVoting (handleProposalCreated) mappings with mock event', (
   // handle event
   _handleProposalCreated(event, DAO_ADDRESS, STRING_DATA);
 
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() +
-    '_' +
-    BigInt.fromString(proposalId).toHexString();
   let packageId = Address.fromString(CONTRACT_ADDRESS).toHexString();
 
   // checks
-  assert.fieldEquals('AddresslistVotingProposal', entityID, 'id', entityID);
-  assert.fieldEquals('AddresslistVotingProposal', entityID, 'dao', DAO_ADDRESS);
+  assert.fieldEquals('AddresslistVotingProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('AddresslistVotingProposal', PROPOSAL_ID, 'dao', DAO_ADDRESS);
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'plugin',
     packageId
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
-    'proposalId',
-    proposalId
-  );
-  assert.fieldEquals(
-    'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'creator',
     ADDRESS_ONE
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'metadata',
     STRING_DATA
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'createdAt',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'creationBlockNumber',
     event.block.number.toString()
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'startDate',
     START_DATE
   );
 
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'votingMode',
     VOTING_MODES.get(parseInt(VOTING_MODE))
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'supportThreshold',
     SUPPORT_THRESHOLD
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'minParticipation',
     MIN_PARTICIPATION
   );
 
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'startDate',
     START_DATE
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'endDate',
     END_DATE
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'snapshotBlock',
     SNAPSHOT_BLOCK
   );
 
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'totalVotingPower',
     TOTAL_VOTING_POWER
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'executed',
     'false'
   );
@@ -371,33 +360,31 @@ test('Run AddresslistVoting (handleVoteCast) mappings with mock event and vote o
 
 test('Run AddresslistVoting (handleProposalExecuted) mappings with mock event', () => {
   // create state
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() + '_' + '0x0';
   createAddresslistVotingProposalEntityState(
-    entityID,
+    PROPOSAL_ID,
     DAO_ADDRESS,
     CONTRACT_ADDRESS,
     ADDRESS_ONE
   );
 
   // create event
-  let event = createNewProposalExecutedEvent('0', CONTRACT_ADDRESS);
+  let event = createNewProposalExecutedEvent(PROPOSAL_ID, CONTRACT_ADDRESS);
 
   // handle event
   handleProposalExecuted(event);
 
   // checks
-  assert.fieldEquals('AddresslistVotingProposal', entityID, 'id', entityID);
-  assert.fieldEquals('AddresslistVotingProposal', entityID, 'executed', 'true');
+  assert.fieldEquals('AddresslistVotingProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('AddresslistVotingProposal', PROPOSAL_ID, 'executed', 'true');
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'executionDate',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'AddresslistVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'executionBlockNumber',
     event.block.number.toString()
   );

--- a/packages/subgraph/tests/addresslist-voting/utils.ts
+++ b/packages/subgraph/tests/addresslist-voting/utils.ts
@@ -13,7 +13,6 @@ import {
 import {
   ADDRESS_ONE,
   DAO_ADDRESS,
-  PROPOSAL_ENTITY_ID,
   PROPOSAL_ID,
   CONTRACT_ADDRESS,
   VOTING_MODE,
@@ -41,7 +40,7 @@ export function createNewProposalCreatedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let creatorParam = new ethereum.EventParam(
     'creator',
@@ -73,7 +72,7 @@ export function createNewVoteCastEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let voterParam = new ethereum.EventParam(
     'voter',
@@ -109,7 +108,7 @@ export function createNewProposalExecutedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let execResultsParam = new ethereum.EventParam(
     'execResults',
@@ -223,11 +222,10 @@ export function getProposalCountCall(
 // state
 
 export function createAddresslistVotingProposalEntityState(
-  entityID: string = PROPOSAL_ENTITY_ID,
+  entityID: string = PROPOSAL_ID,
   dao: string = DAO_ADDRESS,
   pkg: string = CONTRACT_ADDRESS,
   creator: string = ADDRESS_ONE,
-  proposalId: string = PROPOSAL_ID,
 
   open: boolean = true,
   executed: boolean = false,
@@ -248,7 +246,6 @@ export function createAddresslistVotingProposalEntityState(
   let addresslistProposal = new AddresslistVotingProposal(entityID);
   addresslistProposal.dao = Address.fromString(dao).toHexString();
   addresslistProposal.plugin = Address.fromString(pkg).toHexString();
-  addresslistProposal.proposalId = BigInt.fromString(proposalId);
   addresslistProposal.creator = Address.fromString(creator);
 
   addresslistProposal.open = open;

--- a/packages/subgraph/tests/admin/admin.test.ts
+++ b/packages/subgraph/tests/admin/admin.test.ts
@@ -45,22 +45,16 @@ test('Run Admin plugin (handleProposalCreated) mappings with mock event', () => 
   // handle event
   _handleProposalCreated(event, DAO_ADDRESS, STRING_DATA);
 
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() +
-    '_' +
-    BigInt.fromString(PROPOSAL_ID).toHexString();
-
   // checks
-  assert.fieldEquals('AdminProposal', entityID, 'id', entityID);
-  assert.fieldEquals('AdminProposal', entityID, 'dao', DAO_ADDRESS);
-  assert.fieldEquals('AdminProposal', entityID, 'plugin', pluginId);
-  assert.fieldEquals('AdminProposal', entityID, 'proposalId', PROPOSAL_ID);
-  assert.fieldEquals('AdminProposal', entityID, 'creator', ADDRESS_ONE);
-  assert.fieldEquals('AdminProposal', entityID, 'metadata', STRING_DATA);
-  assert.fieldEquals('AdminProposal', entityID, 'executed', 'false');
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'dao', DAO_ADDRESS);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'plugin', pluginId);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'creator', ADDRESS_ONE);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'metadata', STRING_DATA);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'executed', 'false');
   assert.fieldEquals(
     'AdminProposal',
-    entityID,
+    PROPOSAL_ID,
     'createdAt',
     event.block.timestamp.toString()
   );
@@ -89,17 +83,11 @@ test('Run Admin plugin (handleProposalExecuted) mappings with mock event', () =>
   let adminPlugin = new AdminPlugin(pluginId);
   adminPlugin.save();
 
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() +
-    '_' +
-    BigInt.fromString(PROPOSAL_ID).toHexString();
-
   let adminstratorAddress = Address.fromString(ADDRESS_ONE);
 
-  let adminProposal = new AdminProposal(entityID);
+  let adminProposal = new AdminProposal(PROPOSAL_ID);
   adminProposal.dao = DAO_ADDRESS;
   adminProposal.plugin = pluginId;
-  adminProposal.proposalId = BigInt.fromString(PROPOSAL_ID);
   adminProposal.creator = adminstratorAddress;
   adminProposal.metadata = STRING_DATA;
   adminProposal.executed = false;
@@ -107,13 +95,13 @@ test('Run Admin plugin (handleProposalExecuted) mappings with mock event', () =>
   adminProposal.adminstrator = adminstratorAddress.toHexString();
   adminProposal.save();
 
-  const actionId = CONTRACT_ADDRESS + '_' + PROPOSAL_ID + '_' + PROPOSAL_ID;
+  const actionId = PROPOSAL_ID + '_0x00000000000000000000000000000000';
   let action = new Action(actionId);
   action.to = Address.fromString(ADDRESS_TWO);
   action.value = BigInt.fromString(actionValue);
   action.data = Bytes.fromHexString(actionData);
   action.dao = DAO_ADDRESS;
-  action.proposal = entityID;
+  action.proposal = PROPOSAL_ID;
   action.save();
 
   // create event
@@ -127,8 +115,8 @@ test('Run Admin plugin (handleProposalExecuted) mappings with mock event', () =>
   handleProposalExecuted(event);
 
   // checks
-  assert.fieldEquals('AdminProposal', entityID, 'id', entityID);
-  assert.fieldEquals('AdminProposal', entityID, 'executed', 'true');
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('AdminProposal', PROPOSAL_ID, 'executed', 'true');
 
   clearStore();
 });

--- a/packages/subgraph/tests/admin/utils.ts
+++ b/packages/subgraph/tests/admin/utils.ts
@@ -22,7 +22,7 @@ export function createNewProposalCreatedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let creatorParam = new ethereum.EventParam(
     'creator',
@@ -59,7 +59,7 @@ export function createProposalExecutedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
 
   let execResultsBytesArray = new Array<Bytes>();

--- a/packages/subgraph/tests/constants.ts
+++ b/packages/subgraph/tests/constants.ts
@@ -15,9 +15,8 @@ export const ONE = '1';
 export const TWO = '2';
 export const THREE = '3';
 
-export const PROPOSAL_ID = ZERO;
-export const PROPOSAL_ENTITY_ID =
-  Address.fromString(CONTRACT_ADDRESS).toHexString() + '_0x' + PROPOSAL_ID;
+export const PROPOSAL_ID = 
+  `${CONTRACT_ADDRESS.toLowerCase()}${'0'.repeat(24)}`;
 
 export const STRING_DATA = 'Some String Data ...';
 

--- a/packages/subgraph/tests/dao/dao.test.ts
+++ b/packages/subgraph/tests/dao/dao.test.ts
@@ -19,7 +19,8 @@ import {
   STRING_DATA,
   HALF_ETH,
   ADDRESS_ZERO,
-  CONTRACT_ADDRESS
+  CONTRACT_ADDRESS,
+  PROPOSAL_ID
 } from '../constants';
 import {createDummyActions, createTokenCalls} from '../utils';
 import {
@@ -330,9 +331,6 @@ test('Run dao (handleExecuted) for Token mappings with mock event', () => {
   let daoEntity = Address.fromString(DAO_ADDRESS).toHexString();
   createDaoEntityState(daoEntity, ADDRESS_ONE, DAO_TOKEN_ADDRESS);
 
-  let proposalId =
-    Address.fromHexString(CONTRACT_ADDRESS).toHexString() + '_' + '0x0';
-
   createTokenVotingProposalEntityState();
 
   // create token calls
@@ -345,7 +343,7 @@ test('Run dao (handleExecuted) for Token mappings with mock event', () => {
   let actions = createDummyActions(DAO_ADDRESS, '0', callData);
   let event = createNewExecutedEvent(
     Address.fromHexString(CONTRACT_ADDRESS).toHexString(),
-    '0',
+    PROPOSAL_ID,
     actions,
     [Bytes.fromUTF8('')],
     Address.fromHexString(DAO_ADDRESS).toHexString()
@@ -399,7 +397,7 @@ test('Run dao (handleExecuted) for Token mappings with mock event', () => {
     'reference',
     Bytes.fromUTF8(STRING_DATA).toString()
   );
-  assert.fieldEquals('VaultTransfer', entityID, 'proposal', proposalId);
+  assert.fieldEquals('VaultTransfer', entityID, 'proposal', PROPOSAL_ID);
   assert.fieldEquals(
     'VaultTransfer',
     entityID,

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -306,7 +306,7 @@ export function createNewExecutedEvent(
   );
   let callIdParam = new ethereum.EventParam(
     'callId',
-    ethereum.Value.fromUnsignedBigInt(BigInt.fromString(callId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(callId))
   );
   let actionsParam = new ethereum.EventParam(
     'actions',

--- a/packages/subgraph/tests/multisig/multisig.test.ts
+++ b/packages/subgraph/tests/multisig/multisig.test.ts
@@ -23,7 +23,6 @@ import {
   ONE,
   TWO,
   THREE,
-  PROPOSAL_ENTITY_ID
 } from '../constants';
 import {createDummyActions} from '../utils';
 import {
@@ -38,7 +37,6 @@ import {
   createNewMultisigSettingsUpdatedEvent
 } from './utils';
 
-let proposalId = '0';
 let actions = createDummyActions(DAO_TOKEN_ADDRESS, '0', '0x00000000');
 
 test('Run Multisig (handleProposalCreated) mappings with mock event', () => {
@@ -54,7 +52,7 @@ test('Run Multisig (handleProposalCreated) mappings with mock event', () => {
   getProposalCountCall(CONTRACT_ADDRESS, '1');
   createGetProposalCall(
     CONTRACT_ADDRESS,
-    proposalId,
+    PROPOSAL_ID,
     true,
     false,
 
@@ -71,7 +69,7 @@ test('Run Multisig (handleProposalCreated) mappings with mock event', () => {
 
   // create event
   let event = createNewProposalCreatedEvent(
-    proposalId,
+    PROPOSAL_ID,
     ADDRESS_ONE,
     STRING_DATA,
     actions,
@@ -81,47 +79,43 @@ test('Run Multisig (handleProposalCreated) mappings with mock event', () => {
   // handle event
   _handleProposalCreated(event, DAO_ADDRESS, STRING_DATA);
 
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() +
-    '_' +
-    BigInt.fromString(proposalId).toHexString();
+
   let packageId = Address.fromString(CONTRACT_ADDRESS).toHexString();
 
   // checks
-  assert.fieldEquals('MultisigProposal', entityID, 'id', entityID);
-  assert.fieldEquals('MultisigProposal', entityID, 'dao', DAO_ADDRESS);
-  assert.fieldEquals('MultisigProposal', entityID, 'plugin', packageId);
-  assert.fieldEquals('MultisigProposal', entityID, 'proposalId', proposalId);
-  assert.fieldEquals('MultisigProposal', entityID, 'creator', ADDRESS_ONE);
-  assert.fieldEquals('MultisigProposal', entityID, 'metadata', STRING_DATA);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'dao', DAO_ADDRESS);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'plugin', packageId);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'creator', ADDRESS_ONE);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'metadata', STRING_DATA);
   assert.fieldEquals(
     'MultisigProposal',
-    entityID,
+    PROPOSAL_ID,
     'createdAt',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'MultisigProposal',
-    entityID,
+    PROPOSAL_ID,
     'creationBlockNumber',
     event.block.number.toString()
   );
-  assert.fieldEquals('MultisigProposal', entityID, 'open', 'true');
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'open', 'true');
   assert.fieldEquals(
     'MultisigProposal',
-    entityID,
+    PROPOSAL_ID,
     'snapshotBlock',
     SNAPSHOT_BLOCK
   );
-  assert.fieldEquals('MultisigProposal', entityID, 'minApprovals', ONE);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'minApprovals', ONE);
   assert.fieldEquals(
     'MultisigProposal',
-    entityID,
+    PROPOSAL_ID,
     'addresslistLength',
     TOTAL_VOTING_POWER
   );
-  assert.fieldEquals('MultisigProposal', entityID, 'approvals', ONE);
-  assert.fieldEquals('MultisigProposal', entityID, 'executed', 'false');
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'approvals', ONE);
+  assert.fieldEquals('MultisigProposal', PROPOSAL_ID, 'executed', 'false');
 
   // check MultisigPlugin
   assert.fieldEquals(
@@ -137,7 +131,7 @@ test('Run Multisig (handleProposalCreated) mappings with mock event', () => {
 test('Run Multisig (handleApproved) mappings with mock event', () => {
   // create state
   let proposal = createMultisigProposalEntityState(
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     DAO_ADDRESS,
     CONTRACT_ADDRESS,
     ADDRESS_ONE
@@ -146,7 +140,7 @@ test('Run Multisig (handleApproved) mappings with mock event', () => {
   // create calls
   createGetProposalCall(
     CONTRACT_ADDRESS,
-    proposalId,
+    PROPOSAL_ID,
     true,
     false,
 
@@ -244,14 +238,14 @@ test('Run Multisig (handleApproved) mappings with mock event', () => {
 test('Run Multisig (handleProposalExecuted) mappings with mock event', () => {
   // create state
   createMultisigProposalEntityState(
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     DAO_ADDRESS,
     CONTRACT_ADDRESS,
     ADDRESS_ONE
   );
 
   // create event
-  let event = createNewProposalExecutedEvent('0', CONTRACT_ADDRESS);
+  let event = createNewProposalExecutedEvent(PROPOSAL_ID, CONTRACT_ADDRESS);
 
   // handle event
   handleProposalExecuted(event);
@@ -259,25 +253,25 @@ test('Run Multisig (handleProposalExecuted) mappings with mock event', () => {
   // checks
   assert.fieldEquals(
     'MultisigProposal',
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     'id',
-    PROPOSAL_ENTITY_ID
+    PROPOSAL_ID
   );
   assert.fieldEquals(
     'MultisigProposal',
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     'executed',
     'true'
   );
   assert.fieldEquals(
     'MultisigProposal',
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     'executionDate',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'MultisigProposal',
-    PROPOSAL_ENTITY_ID,
+    PROPOSAL_ID,
     'executionBlockNumber',
     event.block.number.toString()
   );
@@ -367,8 +361,8 @@ test('Run Multisig (handleAddressesRemoved) mappings with mock event', () => {
 
 test('Run Multisig (handleMultisigSettingsUpdated) mappings with mock event', () => {
   // create state
-  let entityID = Address.fromString(CONTRACT_ADDRESS).toHexString();
-  let multisigPlugin = new MultisigPlugin(entityID);
+  let PROPOSAL_ID = Address.fromString(CONTRACT_ADDRESS).toHexString();
+  let multisigPlugin = new MultisigPlugin(PROPOSAL_ID);
   multisigPlugin.onlyListed = false;
   multisigPlugin.save();
 
@@ -383,8 +377,8 @@ test('Run Multisig (handleMultisigSettingsUpdated) mappings with mock event', ()
   handleMultisigSettingsUpdated(event);
 
   // checks
-  assert.fieldEquals('MultisigPlugin', entityID, 'onlyListed', 'true');
-  assert.fieldEquals('MultisigPlugin', entityID, 'minApprovals', '5');
+  assert.fieldEquals('MultisigPlugin', PROPOSAL_ID, 'onlyListed', 'true');
+  assert.fieldEquals('MultisigPlugin', PROPOSAL_ID, 'minApprovals', '5');
 
   // create event
   event = createNewMultisigSettingsUpdatedEvent(false, '4', CONTRACT_ADDRESS);
@@ -393,8 +387,8 @@ test('Run Multisig (handleMultisigSettingsUpdated) mappings with mock event', ()
   handleMultisigSettingsUpdated(event);
 
   // checks
-  assert.fieldEquals('MultisigPlugin', entityID, 'onlyListed', 'false');
-  assert.fieldEquals('MultisigPlugin', entityID, 'minApprovals', '4');
+  assert.fieldEquals('MultisigPlugin', PROPOSAL_ID, 'onlyListed', 'false');
+  assert.fieldEquals('MultisigPlugin', PROPOSAL_ID, 'minApprovals', '4');
 
   clearStore();
 });

--- a/packages/subgraph/tests/multisig/utils.ts
+++ b/packages/subgraph/tests/multisig/utils.ts
@@ -13,7 +13,6 @@ import {
 import {
   ADDRESS_ONE,
   DAO_ADDRESS,
-  PROPOSAL_ENTITY_ID,
   PROPOSAL_ID,
   CONTRACT_ADDRESS,
   SNAPSHOT_BLOCK,
@@ -38,7 +37,7 @@ export function createNewProposalCreatedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let creatorParam = new ethereum.EventParam(
     'creator',
@@ -73,7 +72,7 @@ export function createNewApprovedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let approverParam = new ethereum.EventParam(
     'approver',
@@ -99,7 +98,7 @@ export function createNewProposalExecutedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let execResultsParam = new ethereum.EventParam(
     'execResults',
@@ -226,10 +225,10 @@ export function createGetProposalCall(
   createMockedFunction(
     Address.fromString(contractAddress),
     'getProposal',
-    'getProposal(uint256):(bool,bool,(uint256,uint64),(uint256,uint256),(address,uint256,bytes)[])'
+    'getProposal(bytes32):(bool,bool,(uint256,uint64),(uint256,uint256),(address,uint256,bytes)[])'
   )
     .withArgs([
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromString(proposalId))
+      ethereum.Value.fromFixedBytes(Bytes.fromHexString(proposalId))
     ])
     .returns([
       ethereum.Value.fromBoolean(open),
@@ -248,11 +247,10 @@ export function createGetProposalCall(
 // state
 
 export function createMultisigProposalEntityState(
-  entityID: string = PROPOSAL_ENTITY_ID,
+  entityID: string = PROPOSAL_ID,
   dao: string = DAO_ADDRESS,
   plugin: string = CONTRACT_ADDRESS,
   creator: string = ADDRESS_ONE,
-  proposalId: string = PROPOSAL_ID,
   minApprovals: string = TWO,
   open: boolean = true,
   executed: boolean = false,
@@ -268,7 +266,6 @@ export function createMultisigProposalEntityState(
   let multisigProposal = new MultisigProposal(entityID);
   multisigProposal.dao = Address.fromString(dao).toHexString();
   multisigProposal.plugin = Address.fromString(plugin).toHexString();
-  multisigProposal.proposalId = BigInt.fromString(proposalId);
   multisigProposal.creator = Address.fromString(creator);
   multisigProposal.open = open;
   multisigProposal.executed = executed;

--- a/packages/subgraph/tests/token-voting/token-voting.test.ts
+++ b/packages/subgraph/tests/token-voting/token-voting.test.ts
@@ -37,7 +37,6 @@ import {
   createTokenVotingProposalEntityState
 } from './utils';
 
-let proposalId = '0';
 let actions = createDummyActions(DAO_TOKEN_ADDRESS, '0', '0x00000000');
 
 test('Run TokenVoting (handleProposalCreated) mappings with mock event', () => {
@@ -51,7 +50,7 @@ test('Run TokenVoting (handleProposalCreated) mappings with mock event', () => {
   getProposalCountCall(CONTRACT_ADDRESS, '1');
   createGetProposalCall(
     CONTRACT_ADDRESS,
-    proposalId,
+    PROPOSAL_ID,
     true,
     false,
 
@@ -72,7 +71,7 @@ test('Run TokenVoting (handleProposalCreated) mappings with mock event', () => {
 
   // create event
   let event = createNewProposalCreatedEvent(
-    proposalId,
+    PROPOSAL_ID,
     ADDRESS_ONE,
     STRING_DATA,
     CONTRACT_ADDRESS
@@ -81,68 +80,63 @@ test('Run TokenVoting (handleProposalCreated) mappings with mock event', () => {
   // handle event
   _handleProposalCreated(event, DAO_ADDRESS, STRING_DATA);
 
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() +
-    '_' +
-    BigInt.fromString(proposalId).toHexString();
   let packageId = Address.fromString(CONTRACT_ADDRESS).toHexString();
 
   // checks
-  assert.fieldEquals('TokenVotingProposal', entityID, 'id', entityID);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'dao', DAO_ADDRESS);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'plugin', packageId);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'proposalId', proposalId);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'creator', ADDRESS_ONE);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'metadata', STRING_DATA);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'dao', DAO_ADDRESS);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'plugin', packageId);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'creator', ADDRESS_ONE);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'metadata', STRING_DATA);
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'createdAt',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'creationBlockNumber',
     event.block.number.toString()
   );
-  assert.fieldEquals('TokenVotingProposal', entityID, 'startDate', START_DATE);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'startDate', START_DATE);
 
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'votingMode',
     VOTING_MODES.get(parseInt(VOTING_MODE))
   );
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'supportThreshold',
     SUPPORT_THRESHOLD
   );
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'minParticipation',
     MIN_PARTICIPATION
   );
 
-  assert.fieldEquals('TokenVotingProposal', entityID, 'startDate', START_DATE);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'endDate', END_DATE);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'startDate', START_DATE);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'endDate', END_DATE);
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'snapshotBlock',
     SNAPSHOT_BLOCK
   );
 
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'totalVotingPower',
     TOTAL_VOTING_POWER
   );
-  assert.fieldEquals('TokenVotingProposal', entityID, 'executed', 'false');
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'executed', 'false');
 
   // check TokenVotingPlugin
   assert.fieldEquals(
@@ -328,12 +322,8 @@ test('Run TokenVoting (handleVoteCast) mappings with mock event and vote option 
 });
 
 test('Run TokenVoting (handleProposalExecuted) mappings with mock event', () => {
-  // create state
-  let entityID =
-    Address.fromString(CONTRACT_ADDRESS).toHexString() + '_' + '0x0';
-
   createTokenVotingProposalEntityState(
-    entityID,
+    PROPOSAL_ID,
     DAO_ADDRESS,
     CONTRACT_ADDRESS,
     ADDRESS_ONE
@@ -342,7 +332,7 @@ test('Run TokenVoting (handleProposalExecuted) mappings with mock event', () => 
   // create calls
   createGetProposalCall(
     CONTRACT_ADDRESS,
-    proposalId,
+    PROPOSAL_ID,
     true,
     true,
 
@@ -362,23 +352,23 @@ test('Run TokenVoting (handleProposalExecuted) mappings with mock event', () => 
   );
 
   // create event
-  let event = createNewProposalExecutedEvent('0', CONTRACT_ADDRESS);
+  let event = createNewProposalExecutedEvent(PROPOSAL_ID, CONTRACT_ADDRESS);
 
   // handle event
   handleProposalExecuted(event);
 
   // checks
-  assert.fieldEquals('TokenVotingProposal', entityID, 'id', entityID);
-  assert.fieldEquals('TokenVotingProposal', entityID, 'executed', 'true');
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'id', PROPOSAL_ID);
+  assert.fieldEquals('TokenVotingProposal', PROPOSAL_ID, 'executed', 'true');
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'executionDate',
     event.block.timestamp.toString()
   );
   assert.fieldEquals(
     'TokenVotingProposal',
-    entityID,
+    PROPOSAL_ID,
     'executionBlockNumber',
     event.block.number.toString()
   );

--- a/packages/subgraph/tests/token-voting/utils.ts
+++ b/packages/subgraph/tests/token-voting/utils.ts
@@ -11,7 +11,6 @@ import {TokenVotingProposal} from '../../generated/schema';
 import {
   ADDRESS_ONE,
   DAO_ADDRESS,
-  PROPOSAL_ENTITY_ID,
   PROPOSAL_ID,
   CONTRACT_ADDRESS,
   VOTING_MODE,
@@ -39,7 +38,7 @@ export function createNewProposalCreatedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let creatorParam = new ethereum.EventParam(
     'creator',
@@ -71,7 +70,7 @@ export function createNewVoteCastEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let voterParam = new ethereum.EventParam(
     'voter',
@@ -107,7 +106,7 @@ export function createNewProposalExecutedEvent(
 
   let proposalIdParam = new ethereum.EventParam(
     'proposalId',
-    ethereum.Value.fromSignedBigInt(BigInt.fromString(proposalId))
+    ethereum.Value.fromBytes(Bytes.fromHexString(proposalId))
   );
   let execResultsParam = new ethereum.EventParam(
     'execResults',
@@ -183,11 +182,10 @@ export function getProposalCountCall(
 // state
 
 export function createTokenVotingProposalEntityState(
-  entityID: string = PROPOSAL_ENTITY_ID,
+  entityID: string = PROPOSAL_ID,
   dao: string = DAO_ADDRESS,
   pkg: string = CONTRACT_ADDRESS,
   creator: string = ADDRESS_ONE,
-  proposalId: string = PROPOSAL_ID,
 
   open: boolean = true,
   executed: boolean = false,
@@ -208,7 +206,6 @@ export function createTokenVotingProposalEntityState(
   let tokenVotingProposal = new TokenVotingProposal(entityID);
   tokenVotingProposal.dao = Address.fromString(dao).toHexString();
   tokenVotingProposal.plugin = Address.fromString(pkg).toHexString();
-  tokenVotingProposal.proposalId = BigInt.fromString(proposalId);
   tokenVotingProposal.creator = Address.fromString(creator);
 
   tokenVotingProposal.open = open;

--- a/packages/subgraph/tests/utils.ts
+++ b/packages/subgraph/tests/utils.ts
@@ -102,10 +102,10 @@ export function createGetProposalCall(
   createMockedFunction(
     Address.fromString(contractAddress),
     'getProposal',
-    'getProposal(uint256):(bool,bool,(uint8,uint64,uint64,uint64,uint64,uint64),(uint256,uint256,uint256,uint256),(address,uint256,bytes)[])'
+    'getProposal(bytes32):(bool,bool,(uint8,uint64,uint64,uint64,uint64,uint64),(uint256,uint256,uint256,uint256),(address,uint256,bytes)[])'
   )
     .withArgs([
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromString(proposalId))
+      ethereum.Value.fromFixedBytes(Bytes.fromHexString(proposalId))
     ])
     .returns([
       ethereum.Value.fromBoolean(open),


### PR DESCRIPTION
## Description

- changes the `proposalId` to be `bytes32` instead of `uint256` everywhere
- contracts use now a combination of address + counter to generate proposal ID:
      20 bytes from address + 12 bytes from counter to create the ID
- subgraph uses now directly the plugins proposalId because it is now unique

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.