### PR TITLE
Added ERC721 and ERC1155 support

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ERC-721 and ERC-1155 support to `deposit` and `withdraw` in `DAO` and adapted the `Deposited` and `Withdrawn` events.
 - Added `startDate` and `endDate` to the `ProposalCreated` event.
 - Added the `ProposalBase`, `Proposal`, and `ProposalUpgradeable` contracts to refactor and unify the proposal creation and execution process across all governance plugins.
 - Adds `startDate` and `endDate` to Multisig proposals. Execution and approvals of proposals have now to be in the boundaries of these 2 dates.

--- a/packages/contracts/contracts/core/DAO.sol
+++ b/packages/contracts/contracts/core/DAO.sol
@@ -30,8 +30,6 @@ contract DAO is
     Initializable,
     IERC1271,
     ERC165StorageUpgradeable,
-    //IERC721ReceiverUpgradeable, // We use callback handler instead.
-    //IERC1155ReceiverUpgradeable,
     IDAO,
     UUPSUpgradeable,
     PermissionManager,
@@ -103,7 +101,7 @@ contract DAO is
     /// @notice Thrown if a native token withdraw fails.
     error NativeTokenWithdrawFailed();
 
-    /// @notice Thrown when an unsupported token is deposited or withdrawn.
+    /// @notice Thrown if an unsupported token is deposited or withdrawn.
     /// @param token The address of the unsupported token.
     error UnsupportedTokenStandard(address token);
 
@@ -117,7 +115,8 @@ contract DAO is
     }
 
     /// @notice Initializes the DAO by
-    /// - registering the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID
+    /// - registering the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface IDs
+    /// - registering the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) callbacks
     /// - setting the trusted forwarder for meta transactions
     /// - giving the `ROOT_PERMISSION_ID` permission to the initial owner (that should be revoked and transferred to the DAO after setup).
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -72,17 +72,17 @@ interface IDAO {
         bytes4 magicNumber
     );
 
-    /// @notice Emitted when a native token deposit has been made to the DAO.
+    /// @notice Emitted when a native token deposit has been sent directly to the DAO via the `receive` function.
     /// @dev This event is intended to be emitted in the `receive` function and is therefore bound by the gas limitations for `send`/`transfer` calls introduced by [ERC-2929](https://eips.ethereum.org/EIPS/eip-2929).
     /// @param sender The address of the sender.
     /// @param amount The amount of native tokens deposited.
     event NativeTokenDeposited(address sender, uint256 amount);
 
-    /// @notice Emitted when a token deposit has been made to the DAO.
+    /// @notice Emitted when a native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20), [ERC-721](https://eips.ethereum.org/EIPS/eip-721), or [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) token deposit has been made into the DAO.
     /// @param sender The address of the sender.
-    /// @param token The address of the deposited token.
-    /// @param tokenId The ID of the token deposited (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
-    /// @param amount The amount of tokens deposited  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param token The address of the token contract or `address(0)` in case of the native token.
+    /// @param tokenId The ID of the deposited token (applies to ERC-721 and ERC-1155 tokens).
+    /// @param amount The amount of deposited tokens (applies to native, ERC-20 and ERC-1155 tokens).
     /// @param _reference The reference describing the deposit reason.
     event Deposited(
         address indexed sender,
@@ -92,11 +92,11 @@ interface IDAO {
         string _reference
     );
 
-    /// @notice Emitted when a token withdrawal has been made from the DAO.
-    /// @param token The address of the withdrawn token or address(0) in case of the native token.
+    /// @notice Emitted when a native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20), [ERC-721](https://eips.ethereum.org/EIPS/eip-721), and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155 token withdrawal has been made from the DAO.
+    /// @param token The address of the token contract or `address(0)` in case of the native token.
     /// @param to The address of the receiver.
-    /// @param tokenId The ID of the token withdrawn (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
-    /// @param amount The amount of tokens withdrawn  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param tokenId The ID of the withdrawn token (applies to ERC-721 and ERC-1155 tokens).
+    /// @param amount The amount of withdrawn tokens (applies to native, ERC-20 and ERC-1155 tokens).
     /// @param _reference The reference describing the withdrawal reason.
     event Withdrawn(
         address indexed token,
@@ -106,9 +106,10 @@ interface IDAO {
         string _reference
     );
 
-    /// @notice Deposits native tokens to the DAO contract with a reference string.
-    /// @param _tokenId The ID of the token deposited (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
-    /// @param _amount The amount of tokens d  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @notice Deposits native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20), [ERC-721](https://eips.ethereum.org/EIPS/eip-721), and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) into the DAO with a deposit reference string.
+    /// @param _token The address of the token contract or `address(0)` in case of the native token.
+    /// @param _tokenId The ID of the deposited token (applies to ERC-721 and ERC-1155 tokens).
+    /// @param _amount The amount of deposited tokens (applies to native, ERC-20 and ERC-1155 tokens).
     /// @param _reference The reference describing the deposit reason.
     function deposit(
         address _token,
@@ -117,10 +118,11 @@ interface IDAO {
         string calldata _reference
     ) external payable;
 
-    /// @notice Withdraw native tokens from the DAO with a withdraw reference string.
+    /// @notice Withdraws native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20), [ERC-721](https://eips.ethereum.org/EIPS/eip-721), [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) from the DAO with a withdraw reference string.
+    /// @param _token The address of the token contract or `address(0)` in case of the native token.
     /// @param _to The target address to send native tokens to.
-    /// @param _tokenId The ID of the token withdrawn (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
-    /// @param _amount The amount of tokens withdrawn  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _tokenId The ID of the withdrawn token (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _amount The amount of withdrawn tokens (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
     /// @param _reference The reference describing the withdrawal reason.
     function withdraw(
         address _token,

--- a/packages/contracts/contracts/core/IDAO.sol
+++ b/packages/contracts/contracts/core/IDAO.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.10;
 /// @title IDAO
 /// @author Aragon Association - 2022
 /// @notice The interface required for DAOs within the Aragon App DAO framework.
-abstract contract IDAO {
+interface IDAO {
     struct Action {
         address to; // Address to call
         uint256 value; // Value to be sent with the call (for example ETH if on mainnet)
@@ -23,11 +23,11 @@ abstract contract IDAO {
         address _who,
         bytes32 _permissionId,
         bytes memory _data
-    ) external view virtual returns (bool);
+    ) external view returns (bool);
 
     /// @notice Updates the DAO metadata (e.g., an IPFS hash).
     /// @param _metadata The IPFS hash of the new metadata object.
-    function setMetadata(bytes calldata _metadata) external virtual;
+    function setMetadata(bytes calldata _metadata) external;
 
     /// @notice Emitted when the DAO metadata is updated.
     /// @param metadata The IPFS hash of the new metadata object.
@@ -44,7 +44,7 @@ abstract contract IDAO {
         bytes32 callId,
         Action[] memory _actions,
         uint256 _allowFailureMap
-    ) external virtual returns (bytes[] memory, uint256);
+    ) external returns (bytes[] memory, uint256);
 
     /// @notice Emitted when a proposal is executed.
     /// @param actor The address of the caller.
@@ -72,60 +72,71 @@ abstract contract IDAO {
         bytes4 magicNumber
     );
 
-    /// @notice Deposits (native) tokens to the DAO contract with a reference string.
-    /// @param _token The address of the token or address(0) in case of the native token.
-    /// @param _amount The amount of tokens to deposit.
-    /// @param _reference The reference describing the deposit reason.
-    function deposit(
-        address _token,
-        uint256 _amount,
-        string calldata _reference
-    ) external payable virtual;
-
-    /// @notice Emitted when a token deposit has been made to the DAO.
-    /// @param sender The address of the sender.
-    /// @param token The address of the deposited token.
-    /// @param amount The amount of tokens deposited.
-    /// @param _reference The reference describing the deposit reason.
-    event Deposited(
-        address indexed sender,
-        address indexed token,
-        uint256 amount,
-        string _reference
-    );
-
     /// @notice Emitted when a native token deposit has been made to the DAO.
     /// @dev This event is intended to be emitted in the `receive` function and is therefore bound by the gas limitations for `send`/`transfer` calls introduced by [ERC-2929](https://eips.ethereum.org/EIPS/eip-2929).
     /// @param sender The address of the sender.
     /// @param amount The amount of native tokens deposited.
     event NativeTokenDeposited(address sender, uint256 amount);
 
-    /// @notice Withdraw (native) tokens from the DAO with a withdraw reference string.
-    /// @param _token The address of the token and address(0) in case of the native token.
-    /// @param _to The target address to send (native) tokens to.
-    /// @param _amount The amount of (native) tokens to withdraw.
+    /// @notice Emitted when a token deposit has been made to the DAO.
+    /// @param sender The address of the sender.
+    /// @param token The address of the deposited token.
+    /// @param tokenId The ID of the token deposited (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param amount The amount of tokens deposited  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _reference The reference describing the deposit reason.
+    event Deposited(
+        address indexed sender,
+        address indexed token,
+        uint256 tokenId,
+        uint256 amount,
+        string _reference
+    );
+
+    /// @notice Emitted when a token withdrawal has been made from the DAO.
+    /// @param token The address of the withdrawn token or address(0) in case of the native token.
+    /// @param to The address of the receiver.
+    /// @param tokenId The ID of the token withdrawn (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param amount The amount of tokens withdrawn  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _reference The reference describing the withdrawal reason.
+    event Withdrawn(
+        address indexed token,
+        address indexed to,
+        uint256 tokenId,
+        uint256 amount,
+        string _reference
+    );
+
+    /// @notice Deposits native tokens to the DAO contract with a reference string.
+    /// @param _tokenId The ID of the token deposited (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _amount The amount of tokens d  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _reference The reference describing the deposit reason.
+    function deposit(
+        address _token,
+        uint256 _tokenId,
+        uint256 _amount,
+        string calldata _reference
+    ) external payable;
+
+    /// @notice Withdraw native tokens from the DAO with a withdraw reference string.
+    /// @param _to The target address to send native tokens to.
+    /// @param _tokenId The ID of the token withdrawn (applies to [ERC-721](https://eips.ethereum.org/EIPS/eip-721) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
+    /// @param _amount The amount of tokens withdrawn  (applies to native, [ERC-20](https://eips.ethereum.org/EIPS/eip-20) and [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155) tokens).
     /// @param _reference The reference describing the withdrawal reason.
     function withdraw(
         address _token,
         address _to,
+        uint256 _tokenId,
         uint256 _amount,
         string memory _reference
-    ) external virtual;
-
-    /// @notice Emitted when a (native) token withdrawal has been made from the DAO.
-    /// @param token The address of the withdrawn token or address(0) in case of the native token.
-    /// @param to The address of the withdrawer.
-    /// @param amount The amount of tokens withdrawn.
-    /// @param _reference The reference describing the withdrawal reason.
-    event Withdrawn(address indexed token, address indexed to, uint256 amount, string _reference);
+    ) external;
 
     /// @notice Setter for the trusted forwarder verifying the meta transaction.
     /// @param _trustedForwarder The trusted forwarder address.
-    function setTrustedForwarder(address _trustedForwarder) external virtual;
+    function setTrustedForwarder(address _trustedForwarder) external;
 
     /// @notice Getter for the trusted forwarder verifying the meta transaction.
     /// @return The trusted forwarder address.
-    function getTrustedForwarder() external virtual returns (address);
+    function getTrustedForwarder() external returns (address);
 
     /// @notice Emitted when a new TrustedForwarder is set on the DAO.
     /// @param forwarder the new forwarder address.
@@ -133,7 +144,7 @@ abstract contract IDAO {
 
     /// @notice Setter for the [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validator contract.
     /// @param _signatureValidator The address of the signature validator.
-    function setSignatureValidator(address _signatureValidator) external virtual;
+    function setSignatureValidator(address _signatureValidator) external;
 
     /// @notice Emitted when the signature validator address is updated.
     /// @param signatureValidator The address of the signature validator.
@@ -143,10 +154,7 @@ abstract contract IDAO {
     /// @param _hash The keccak256 hash of arbitrary length data signed on the behalf of `address(this)`.
     /// @param _signature Signature byte array associated with _data.
     /// @return magicValue Returns the `bytes4` magic value `0x1626ba7e` if the signature is valid.
-    function isValidSignature(bytes32 _hash, bytes memory _signature)
-        external
-        virtual
-        returns (bytes4);
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external returns (bytes4);
 
     /// @notice Registers an ERC standard having a callback by registering its [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID and callback function signature.
     /// @param _interfaceId The ID of the interface.
@@ -156,5 +164,5 @@ abstract contract IDAO {
         bytes4 _interfaceId,
         bytes4 _callbackSelector,
         bytes4 _magicNumber
-    ) external virtual;
+    ) external;
 }

--- a/packages/contracts/contracts/core/component/CallbackHandler.sol
+++ b/packages/contracts/contracts/core/component/CallbackHandler.sol
@@ -20,7 +20,7 @@ contract CallbackHandler {
 
     /// @notice Handles callbacks to adaptively support ERC standards.
     /// @param _callbackSelector The selector of the callback function.
-    /// @dev This function is supposed to be called via `_handleCallback(msg.sig, msg.data)` in the `fallback()` function of the inheriting contract.
+    /// @dev This function is supposed to be called via `_handleCallback(msg.sig)` in the `fallback()` function of the inheriting contract.
     function _handleCallback(bytes4 _callbackSelector) internal view {
         bytes32 magicNumber = callbackMagicNumbers[_callbackSelector];
         if (magicNumber == UNREGISTERED_CALLBACK) {

--- a/packages/contracts/contracts/test/DAOMock.sol
+++ b/packages/contracts/contracts/test/DAOMock.sol
@@ -16,9 +16,9 @@ contract DAOMock is IDAO, PermissionManager {
     }
 
     function hasPermission(
-        address, /* _where */
-        address, /* _who */
-        bytes32, /* _permissionId */
+        address /* _where */,
+        address /* _who */,
+        bytes32 /* _permissionId */,
         bytes memory /* _data */
     ) public pure override returns (bool) {
         return true;
@@ -28,42 +28,38 @@ contract DAOMock is IDAO, PermissionManager {
         return address(0);
     }
 
-    function setTrustedForwarder(
-        address /* _trustedForwarder */
-    ) external override {}
+    function setTrustedForwarder(address /* _trustedForwarder */) external override {}
 
-    function setMetadata(
-        bytes calldata /* _metadata */
-    ) external override {}
+    function setMetadata(bytes calldata /* _metadata */) external override {}
 
-    function execute(bytes32 callId, Action[] memory _actions, uint256 allowFailureMap)
-        external
-        override
-        returns (bytes[] memory execResults, uint256 failureMap)
-    {
+    function execute(
+        bytes32 callId,
+        Action[] memory _actions,
+        uint256 allowFailureMap
+    ) external override returns (bytes[] memory execResults, uint256 failureMap) {
         (allowFailureMap);
         emit Executed(msg.sender, callId, _actions, failureMap, execResults);
     }
 
     function deposit(
-        address, /* _token */
-        uint256, /* _amount */
-        string calldata /* _reference */
-    ) external payable override {}
+        address /*_token*/,
+        uint256 /*_tokenId*/,
+        uint256 /*_amount*/,
+        string calldata /*_reference*/
+    ) external payable {}
 
     function withdraw(
-        address, /* _token */
-        address, /* _to */
-        uint256, /* _amount */
-        string memory /* _reference */
-    ) public override {}
+        address /*_token*/,
+        address /*_to*/,
+        uint256 /*_tokenId*/,
+        uint256 /*_amount*/,
+        string memory /*_reference*/
+    ) external {}
 
-    function setSignatureValidator(
-        address /* _signatureValidator */
-    ) external override {}
+    function setSignatureValidator(address /* _signatureValidator */) external override {}
 
     function isValidSignature(
-        bytes32, /* _hash */
+        bytes32 /* _hash */,
         bytes memory /* _signature */
     ) external pure override returns (bytes4) {
         return 0x0;

--- a/packages/contracts/contracts/test/TestERC1155.sol
+++ b/packages/contracts/contracts/test/TestERC1155.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract TestERC1155 is ERC1155 {
+    constructor(string memory URI_) ERC1155(URI_) {}
+
+    function mint(address account, uint256 tokenId, uint256 amount) public {
+        _mint(account, tokenId, amount, bytes(""));
+    }
+
+    function burn(address account, uint256 tokenId, uint256 amount) public {
+        _burn(account, tokenId, amount);
+    }
+}

--- a/packages/contracts/contracts/test/TestERC20.sol
+++ b/packages/contracts/contracts/test/TestERC20.sol
@@ -5,22 +5,13 @@ pragma solidity 0.8.10;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract TestERC20 is ERC20 {
-    constructor(
-        string memory name_,
-        string memory symbol_,
-        uint256 amountToMint
-    ) ERC20(name_, symbol_) {
-        setBalance(msg.sender, amountToMint);
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
     }
 
-    // sets the balance of the address
-    // this mints/burns the amount depending on the current balance
-    function setBalance(address to, uint256 amount) public {
-        uint256 old = balanceOf(to);
-        if (old < amount) {
-            _mint(to, amount - old);
-        } else if (old > amount) {
-            _burn(to, old - amount);
-        }
+    function burn(address account, uint256 amount) public {
+        _burn(account, amount);
     }
 }

--- a/packages/contracts/contracts/test/TestERC721.sol
+++ b/packages/contracts/contracts/test/TestERC721.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract TestERC721 is ERC721 {
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
+
+    function mint(address account, uint256 tokenId) public {
+        _mint(account, tokenId);
+    }
+
+    function burn(address account, uint256 tokenId) public {
+        _burn(tokenId);
+    }
+}

--- a/packages/contracts/test/merkle/merkle-distributor.ts
+++ b/packages/contracts/test/merkle/merkle-distributor.ts
@@ -28,7 +28,7 @@ describe('MerkleDistributor', function () {
     dao = await deployNewDAO(wallet0);
 
     const TestERC20 = await ethers.getContractFactory('TestERC20');
-    token = await TestERC20.deploy('FOO', 'FOO', 0); // mint 0 FOO tokens
+    token = await TestERC20.deploy('FOO', 'FOO');
 
     const MerkleDistributor = await ethers.getContractFactory(
       'MerkleDistributor'
@@ -83,7 +83,7 @@ describe('MerkleDistributor', function () {
         token.address,
         tree.getHexRoot()
       );
-      await token.setBalance(distributor.address, 201);
+      await token.mint(distributor.address, 201);
     });
 
     it('successful claim', async () => {
@@ -106,7 +106,7 @@ describe('MerkleDistributor', function () {
 
     it('must have enough to transfer', async () => {
       const proof0 = tree.getProof(0, wallet0, BigNumber.from(100));
-      await token.setBalance(distributor.address, 99);
+      await token.burn(distributor.address, 102); // 99 tokens remain
       await expect(
         distributor.claim(0, wallet0, 100, proof0)
       ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
@@ -209,7 +209,7 @@ describe('MerkleDistributor', function () {
         token.address,
         tree.getHexRoot()
       );
-      await token.setBalance(distributor.address, 201);
+      await token.mint(distributor.address, 201);
     });
 
     it('claim index 4', async () => {


### PR DESCRIPTION
## Description

Added ERC-721 and ERC-1155 support to `deposit` and `withdraw` in `DAO` and adapted the `Deposited` and `Withdrawn` events.

Note that our `IDAO` was, accidentally, no `interface` but an `abstract contract`. I changed this too.

Tasks: 
- [APP-1659](https://aragonassociation.atlassian.net/browse/APP-1659)
- [APP-1660](https://aragonassociation.atlassian.net/browse/APP-1660)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.

[APP-1659]: https://aragonassociation.atlassian.net/browse/APP-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-1660]: https://aragonassociation.atlassian.net/browse/APP-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ