### PR TITLE
plugin repo types changes

### DIFF
--- a/packages/contracts/contracts/plugin/PluginRepo.sol
+++ b/packages/contracts/contracts/plugin/PluginRepo.sol
@@ -84,11 +84,7 @@ contract PluginRepo is
     /// @param release the release number in which pluginSetup is found.
     /// @param build the build number of the release number in which pluginSetup is found.
     /// @param pluginSetup the plugin setup address.
-    error PluginSetupAlreadyInPreviousRelease(
-        uint8 release,
-        uint16 build,
-        address pluginSetup
-    );
+    error PluginSetupAlreadyInPreviousRelease(uint8 release, uint16 build, address pluginSetup);
 
     /// @notice Thrown if the same plugin setup exists in previous releases.
     /// @param release the release number
@@ -107,7 +103,7 @@ contract PluginRepo is
     constructor() {
         _disableInitializers();
     }
-    
+
     /// @notice Initializes the contract by
     /// - registering the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID
     /// - initializing the permission manager
@@ -195,19 +191,12 @@ contract PluginRepo is
             );
         }
 
-        uint16 build;
-        unchecked {
-            build = ++buildsPerRelease[_release];
-        }
+        uint16 build = ++buildsPerRelease[_release];
 
         Tag memory tag = Tag(_release, build);
         bytes32 _tagHash = tagHash(tag);
 
-        versions[_tagHash] = Version(
-            tag,
-            _pluginSetup,
-            _contentURI
-        );
+        versions[_tagHash] = Version(tag, _pluginSetup, _contentURI);
 
         latestTagHashForPluginSetup[_pluginSetup] = _tagHash;
 
@@ -232,22 +221,14 @@ contract PluginRepo is
     /// @notice get the version by tag.
     /// @param _tag the version tag.
     /// @return the version which belongs to the _tag.
-    function getVersion(Tag calldata _tag)
-        public
-        view
-        returns (Version memory)
-    {
+    function getVersion(Tag calldata _tag) public view returns (Version memory) {
         return getVersion(tagHash(_tag));
     }
 
     /// @notice get the concrete version.
     /// @param _tagHash the tag hash.
     /// @return Version the concrete version by the exact hash.
-    function getVersion(bytes32 _tagHash)
-        public
-        view
-        returns (Version memory)
-    {
+    function getVersion(bytes32 _tagHash) public view returns (Version memory) {
         Version storage version = versions[_tagHash];
 
         if (version.tag.release == 0) {
@@ -263,7 +244,7 @@ contract PluginRepo is
     function buildCount(uint8 _release) public view returns (uint256) {
         return buildsPerRelease[_release];
     }
-    
+
     /// @notice get the tag hash.
     /// @param _tag the tag.
     /// @return bytes32 the keccak hash of abi encoded _release and _build
@@ -273,12 +254,9 @@ contract PluginRepo is
 
     /// @notice Internal method authorizing the upgrade of the contract via the [upgradeabilty mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
     /// @dev The caller must have the `UPGRADE_REPO_PERMISSION_ID` permission.
-    function _authorizeUpgrade(address)
-        internal
-        virtual
-        override
-        auth(address(this), UPGRADE_REPO_PERMISSION_ID)
-    {}
+    function _authorizeUpgrade(
+        address
+    ) internal virtual override auth(address(this), UPGRADE_REPO_PERMISSION_ID) {}
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param interfaceId The ID of the interface.

--- a/packages/contracts/contracts/plugin/PluginRepo.sol
+++ b/packages/contracts/contracts/plugin/PluginRepo.sol
@@ -197,7 +197,7 @@ contract PluginRepo is
 
         uint16 build;
         unchecked {
-            build = uint16(++buildsPerRelease[_release]);
+            build = ++buildsPerRelease[_release];
         }
 
         Tag memory tag = Tag(_release, build);
@@ -213,7 +213,6 @@ contract PluginRepo is
 
         emit VersionCreated(_release, build, _pluginSetup, _contentURI);
     }
-
 
     /// @notice latest version in the release number.
     /// @param _release the release number.

--- a/packages/contracts/contracts/plugin/PluginRepo.sol
+++ b/packages/contracts/contracts/plugin/PluginRepo.sol
@@ -42,13 +42,8 @@ contract PluginRepo is
     /// @notice The ID of the permission required to call the `createVersion` function.
     bytes32 public constant UPGRADE_REPO_PERMISSION_ID = keccak256("UPGRADE_REPO_PERMISSION");
 
-    /// @notice The ID of the latest release.
-    /// @dev The maximum release ID is 255 as it is later stored as an `uint8` inside `Version.tag`.
-    uint256 public latestRelease;
-
     /// @notice increasing build numbers per release
-    /// @dev keys can only be uint8 even though uint256 is specified to reduce gas cost.
-    mapping(uint256 => uint256) internal buildsPerRelease;
+    mapping(uint8 => uint16) internal buildsPerRelease;
 
     /// @notice The mapping between version hash and its corresponding Version information.
     /// @dev key: keccak(abi.encode(release, build)) value: Version struct.
@@ -56,6 +51,10 @@ contract PluginRepo is
 
     /// @notice The mapping between plugin setup address and its corresponding versionHash
     mapping(address => bytes32) internal latestTagHashForPluginSetup;
+
+    /// @notice The ID of the latest release.
+    /// @dev The maximum release ID is 255.
+    uint8 public latestRelease;
 
     /// @notice Thrown if version does not exist.
     /// @param versionHash The version Hash(release + build)
@@ -79,7 +78,7 @@ contract PluginRepo is
     /// @notice Thrown if release id is by more than 1 to the previous release id.
     /// @param currentRelease the current latest release id.
     /// @param newRelease new release id dev is trying to push.
-    error ReleaseIdIncrementInvalid(uint256 currentRelease, uint256 newRelease);
+    error ReleaseIdIncrementInvalid(uint8 currentRelease, uint8 newRelease);
 
     /// @notice Thrown if the same plugin setup exists in previous releases.
     /// @param release the release number in which pluginSetup is found.
@@ -152,7 +151,7 @@ contract PluginRepo is
 
     /// @inheritdoc IPluginRepo
     function createVersion(
-        uint8 _release, // 1
+        uint8 _release,
         address _pluginSetup,
         bytes calldata _contentURI
     ) external auth(address(this), CREATE_VERSION_PERMISSION_ID) {


### PR DESCRIPTION
## Description

Reducing types. I had uint256 previously in mappings to reduce costs ! as you know, handling `uint8` in one slot(while there's no other thing in there) costs more than handling `uint256`. but this might make the confusion that `Tag` is `uint8, uint16`, but in the mapping, we use `uint256` instead of `uint8/16`. Since the costs will not be increased too much, I think it might be better to remove the confusion. Thoughts ? If you agree, then, review ! if not, I got no problem leaving as it is too.

@mathewmeconry @brickpop 

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.