### PR TITLE
remove merkleminter/distributor from tokenvotingsetup

### DIFF
--- a/packages/contracts/contracts/voting/token/TokenVotingSetup.sol
+++ b/packages/contracts/contracts/voting/token/TokenVotingSetup.sol
@@ -42,12 +42,6 @@ contract TokenVotingSetup is PluginSetup {
     /// @notice The address of the `GovernanceWrappedERC20` base contract.
     address public immutable governanceWrappedERC20Base;
 
-    /// @notice The address of the `MerkleMinter` base contract.
-    address public immutable merkleMinterBase;
-
-    /// @notice The `MerkleDistributor` base contract used to initialize the `MerkleMinter`.
-    address public immutable distributorBase;
-
     struct TokenSettings {
         address addr;
         string name;
@@ -73,7 +67,6 @@ contract TokenVotingSetup is PluginSetup {
 
     /// @notice The contract constructor, that deployes the bases.
     constructor() {
-        distributorBase = address(new MerkleDistributor());
         governanceERC20Base = address(
             new GovernanceERC20(
                 IDAO(address(0)),
@@ -85,7 +78,6 @@ contract TokenVotingSetup is PluginSetup {
         governanceWrappedERC20Base = address(
             new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "")
         );
-        merkleMinterBase = address(new MerkleMinter());
         tokenVotingBase = new TokenVoting();
     }
 

--- a/packages/contracts/contracts/voting/token/TokenVotingSetup.sol
+++ b/packages/contracts/contracts/voting/token/TokenVotingSetup.sol
@@ -16,8 +16,6 @@ import {PluginSetup, IPluginSetup} from "../../plugin/PluginSetup.sol";
 import {GovernanceERC20} from "../../tokens/GovernanceERC20.sol";
 import {GovernanceWrappedERC20} from "../../tokens/GovernanceWrappedERC20.sol";
 import {IGovernanceWrappedERC20} from "../../tokens/IGovernanceWrappedERC20.sol";
-import {MerkleMinter} from "../../tokens/MerkleMinter.sol";
-import {MerkleDistributor} from "../../tokens/MerkleDistributor.sol";
 import {IERC20MintableUpgradeable} from "../../tokens/IERC20MintableUpgradeable.sol";
 import {MajorityVotingBase} from "../majority/MajorityVotingBase.sol";
 import {TokenVoting} from "./TokenVoting.sol";


### PR DESCRIPTION
## Description

As far as I remember, we decided to remove merkle minter/distributor from token-voting-setup due to complexity and not bringing value. 

Not sure what the values are for merkle minter and merkle distributor now. Maybe we will design a plugin that will be called MerkleMinterAndDistributor plugin and will install this plugin ? Should it be even the plugin ? if not, how else can dao use it without installing ? 

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.