### PR TITLE
Removed the forgotten `WITHDRAW_PERMISSION` and other permission-related fixes

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the `WITHDRAW_PERMISSION_ID`.
 - Removed `DaoAuthorizableCloneable` and `DaoAuthorizableBase`.
 - Moved the array length check for the `MintSettings` from `TokenVotingSetup` into `GovernanceERC20` contract.
 

--- a/packages/contracts/docs/core/01-how-it-works/01-the-core-contracts/01-the-dao-contract.md
+++ b/packages/contracts/docs/core/01-how-it-works/01-the-core-contracts/01-the-dao-contract.md
@@ -19,7 +19,6 @@ struct Action {
   uint256 value; // The value to be sent with the call (for example ETH if on mainnet)
   bytes data; // The `bytes4` function signature and arguments
 }
-
 ```
 
 Actions are typically scheduled in a proposal in a governance [plugin customizing your DAO](03-plugins.md) can be calls to external contracts, plugins, or the aragonOS DAO framework infrastructure, for example, to [setup a plugin](../02-the-dao-framework/02-plugin-repository/04-plugin-setup.md).
@@ -32,7 +31,10 @@ Multiple `Action` structs can be put into one `Action[]` array and executed in a
 /// @param callId The id of the call. The definition of the value of `callId` is up to the calling contract and can be used, e.g., as a nonce.
 /// @param _actions The array of actions.
 /// @return bytes[] The array of results obtained from the executed actions in `bytes`.
-function execute(uint256 callId, Action[] memory _actions)
+function execute(
+  uint256 callId,
+  Action[] memory _actions
+)
   external
   override
   auth(address(this), EXECUTE_PERMISSION_ID)
@@ -52,7 +54,6 @@ function execute(uint256 callId, Action[] memory _actions)
 
   return execResults;
 }
-
 ```
 
 ### 2. Asset Management
@@ -92,7 +93,7 @@ Lastly, it is essential that only the right entities (e.g., the DAO itself or tr
 
 This is why aragonOS DAOs contain a flexible and battle-tested **permission manager** being able to assign permissions for the above functionalities to specific addresses.
 
-Although possible, the permissions to withdraw assets, execute arbitrary actions or upgrade the DAO should not be given to externally owned accounts (EOA) as this poses a security risk to the organization if the account is compromised or acts adverserial.
+Although possible, the permissions to execute arbitrary actions or upgrade the DAO should not be given to externally owned accounts (EOA) as this poses a security risk to the organization if the account is compromised or acts adverserial.
 
 Instead, the permissions for the above-mentioned functionalities are better restricted to the `DAO` contract itself and triggered through governance [plugins](03-plugins.md) that you can install on your DAO.
 

--- a/packages/contracts/docs/core/01-how-it-works/01-the-core-contracts/03-plugins.md
+++ b/packages/contracts/docs/core/01-how-it-works/01-the-core-contracts/03-plugins.md
@@ -11,7 +11,7 @@ Plugins can be related to:
 - **Governance:** provides the DAO with different **decision-making** mechanisms such as token or address-based majority voting, conviction voting, optimistic governance, or direct execution from an admin address. They are characterized by requiring the `EXECUTE_PERMISSION_ID` permission on the DAO.
   Advanced governance architectures are possible by having multiple governance plugins simultaneously.
 
-- **Finance:** allows the DAO to manage its **treasury** or use it to invest (e.g., in lending, staking, or NFT mints). Often, they require the `WITHDRAW_PERMISSION_ID` permission on the DAO.
+- **Finance:** allows the DAO to manage its **treasury** or use it to invest (e.g., in lending, staking, or NFT mints).
 
 - **Membership:** determines **who** will be a part of the DAO and their roles within them. This can mean minting governance tokens like [ERC-20](https://eips.ethereum.org/EIPS/eip-20), NFTs, or any other token standard. Typically, membership related plugins grant permissions (e.g., based on token ownership) to other addresses.
 

--- a/packages/contracts/docs/core/01-how-it-works/02-the-dao-framework/02-plugin-repository/04-plugin-setup.md
+++ b/packages/contracts/docs/core/01-how-it-works/02-the-dao-framework/02-plugin-repository/04-plugin-setup.md
@@ -8,7 +8,7 @@ A DAO can be set up and customized by the **installation**, **update, and** **un
 In this section you will learn how the plugin setup process in aragonOS works.
 
 In order for a plugin to function, associated contracts need to be deployed and gathered, often requiring permissions from the DAO.  
-For ex, a finance plugin might need the permission to `withdraw` assets from the treasury and a governance plugin will need permission to `execute` actions in the DAO.
+For example, a governance plugin will need permission to call the `execute` function in the DAO.
 
 The required setup logic is written and taken care off by the plugin developer in the `PluginSetup` contract they create and that is associated with each `Plugin` contract version release (see [Developing a Plugin](docs/core/02-how-to-guides/01-plugin-development/index.md)). The `PluginSetup` contract then interacts with the aragonOS framework so that installing, updating, and uninstalling a plugin to a DAO through the UI becomes very simple for the DAO end-user.
 

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -76,16 +76,13 @@ contract DAO is
     /// @param index Index of action in the array that failed.
     error ActionFailed(uint256 index);
 
-    /// @notice Thrown if the deposit or withdraw amount is zero.
+    /// @notice Thrown if the deposit amount is zero.
     error ZeroAmount();
 
     /// @notice Thrown if there is a mismatch between the expected and actually deposited amount of native tokens.
     /// @param expected The expected native token amount.
     /// @param actual The actual native token amount deposited.
     error NativeTokenDepositAmountMismatch(uint256 expected, uint256 actual);
-
-    /// @notice Thrown if a native token withdraw fails.
-    error NativeTokenWithdrawFailed();
 
     /// @notice Emitted when a new DAO uri is set.
     /// @param daoURI The new uri.

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -126,6 +126,7 @@ contract DAO is
             _permissionId == EXECUTE_PERMISSION_ID ||
             _permissionId == UPGRADE_DAO_PERMISSION_ID ||
             _permissionId == SET_METADATA_PERMISSION_ID ||
+            _permissionId == SET_TRUSTED_FORWARDER_PERMISSION_ID ||
             _permissionId == SET_SIGNATURE_VALIDATOR_PERMISSION_ID ||
             _permissionId == REGISTER_STANDARD_CALLBACK_PERMISSION_ID;
     }

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -45,9 +45,6 @@ contract DAO is
     /// @notice The ID of the permission required to call the `setMetadata` function.
     bytes32 public constant SET_METADATA_PERMISSION_ID = keccak256("SET_METADATA_PERMISSION");
 
-    /// @notice The ID of the permission required to call the `withdraw` function.
-    bytes32 public constant WITHDRAW_PERMISSION_ID = keccak256("WITHDRAW_PERMISSION");
-
     /// @notice The ID of the permission required to call the `setTrustedForwarder` function.
     bytes32 public constant SET_TRUSTED_FORWARDER_PERMISSION_ID =
         keccak256("SET_TRUSTED_FORWARDER_PERMISSION");
@@ -132,7 +129,6 @@ contract DAO is
             _permissionId == EXECUTE_PERMISSION_ID ||
             _permissionId == UPGRADE_DAO_PERMISSION_ID ||
             _permissionId == SET_METADATA_PERMISSION_ID ||
-            _permissionId == WITHDRAW_PERMISSION_ID ||
             _permissionId == SET_SIGNATURE_VALIDATOR_PERMISSION_ID ||
             _permissionId == REGISTER_STANDARD_CALLBACK_PERMISSION_ID;
     }

--- a/packages/contracts/src/framework/dao/DAOFactory.sol
+++ b/packages/contracts/src/framework/dao/DAOFactory.sol
@@ -148,7 +148,7 @@ contract DAOFactory {
     function _setDAOPermissions(DAO _dao) internal {
         // set permissionIds on the dao itself.
         PermissionLib.SingleTargetPermission[]
-            memory items = new PermissionLib.SingleTargetPermission[](5);
+            memory items = new PermissionLib.SingleTargetPermission[](6);
 
         // Grant DAO all the permissions required
         items[0] = PermissionLib.SingleTargetPermission(
@@ -175,6 +175,11 @@ contract DAOFactory {
             PermissionLib.Operation.Grant,
             address(_dao),
             _dao.SET_METADATA_PERMISSION_ID()
+        );
+        items[5] = PermissionLib.SingleTargetPermission(
+            PermissionLib.Operation.Grant,
+            address(_dao),
+            _dao.REGISTER_STANDARD_CALLBACK_PERMISSION_ID()
         );
 
         _dao.applySingleTargetPermissions(address(_dao), items);

--- a/packages/contracts/src/framework/dao/DAOFactory.sol
+++ b/packages/contracts/src/framework/dao/DAOFactory.sol
@@ -148,7 +148,7 @@ contract DAOFactory {
     function _setDAOPermissions(DAO _dao) internal {
         // set permissionIds on the dao itself.
         PermissionLib.SingleTargetPermission[]
-            memory items = new PermissionLib.SingleTargetPermission[](6);
+            memory items = new PermissionLib.SingleTargetPermission[](5);
 
         // Grant DAO all the permissions required
         items[0] = PermissionLib.SingleTargetPermission(
@@ -159,24 +159,19 @@ contract DAOFactory {
         items[1] = PermissionLib.SingleTargetPermission(
             PermissionLib.Operation.Grant,
             address(_dao),
-            _dao.WITHDRAW_PERMISSION_ID()
+            _dao.UPGRADE_DAO_PERMISSION_ID()
         );
         items[2] = PermissionLib.SingleTargetPermission(
             PermissionLib.Operation.Grant,
             address(_dao),
-            _dao.UPGRADE_DAO_PERMISSION_ID()
+            _dao.SET_SIGNATURE_VALIDATOR_PERMISSION_ID()
         );
         items[3] = PermissionLib.SingleTargetPermission(
             PermissionLib.Operation.Grant,
             address(_dao),
-            _dao.SET_SIGNATURE_VALIDATOR_PERMISSION_ID()
-        );
-        items[4] = PermissionLib.SingleTargetPermission(
-            PermissionLib.Operation.Grant,
-            address(_dao),
             _dao.SET_TRUSTED_FORWARDER_PERMISSION_ID()
         );
-        items[5] = PermissionLib.SingleTargetPermission(
+        items[4] = PermissionLib.SingleTargetPermission(
             PermissionLib.Operation.Grant,
             address(_dao),
             _dao.SET_METADATA_PERMISSION_ID()

--- a/packages/contracts/test/core/dao/dao.ts
+++ b/packages/contracts/test/core/dao/dao.ts
@@ -53,7 +53,6 @@ const PERMISSION_IDS = {
   UPGRADE_DAO_PERMISSION_ID: UPGRADE_PERMISSIONS.UPGRADE_DAO_PERMISSION_ID,
   SET_METADATA_PERMISSION_ID: ethers.utils.id('SET_METADATA_PERMISSION'),
   EXECUTE_PERMISSION_ID: ethers.utils.id('EXECUTE_PERMISSION'),
-  WITHDRAW_PERMISSION_ID: ethers.utils.id('WITHDRAW_PERMISSION'),
   SET_SIGNATURE_VALIDATOR_PERMISSION_ID: ethers.utils.id(
     'SET_SIGNATURE_VALIDATOR_PERMISSION'
   ),
@@ -95,11 +94,6 @@ describe('DAO', function () {
         dao.address,
         ownerAddress,
         PERMISSION_IDS.EXECUTE_PERMISSION_ID
-      ),
-      dao.grant(
-        dao.address,
-        ownerAddress,
-        PERMISSION_IDS.WITHDRAW_PERMISSION_ID
       ),
       dao.grant(
         dao.address,

--- a/packages/contracts/test/framework/dao/dao-factory.ts
+++ b/packages/contracts/test/framework/dao/dao-factory.ts
@@ -33,7 +33,6 @@ const APPLY_INSTALLATION_PERMISSION_ID = ethers.utils.id(
   'APPLY_INSTALLATION_PERMISSION'
 );
 const ROOT_PERMISSION_ID = ethers.utils.id('ROOT_PERMISSION');
-const WITHDRAW_PERMISSION_ID = ethers.utils.id('WITHDRAW_PERMISSION');
 const UPGRADE_DAO_PERMISSION_ID = ethers.utils.id('UPGRADE_DAO_PERMISSION');
 const SET_SIGNATURE_VALIDATOR_PERMISSION_ID = ethers.utils.id(
   'SET_SIGNATURE_VALIDATOR_PERMISSION'
@@ -307,15 +306,6 @@ describe.skip('DAOFactory: ', function () {
       .to.emit(daoContract, EVENTS.Granted)
       .withArgs(
         ROOT_PERMISSION_ID,
-        daoFactory.address,
-        dao,
-        dao,
-        PermissionManagerAllowFlagAddress
-      );
-    await expect(tx)
-      .to.emit(daoContract, EVENTS.Granted)
-      .withArgs(
-        WITHDRAW_PERMISSION_ID,
         daoFactory.address,
         dao,
         dao,


### PR DESCRIPTION
## Description

- removed `WITHDRAW_PERMISSION` that had remained on `DAO.sol` despite not being used
- added`REGISTER_STANDARD_CALLBACK_PERMISSION` in `DAOFactory` that was not granted
- added `SET_TRUSTED_FORWARDER_PERMISSION` to the list of restricted permissions in `function isPermissionRestrictedForAnyAddr` that was not present there

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.