### PR TITLE
Remove `PermissionManager` feature

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored the `auth` modifier to always use `where = address(this)` and adapted errors.
 - Use OZ's upgradeable contracts for `PluginCloneable`.
 - Renamed `getDAO()` to `dao()` and changed the `dao` state variable mutability to private.
 
 ### Removed
 
-- Refactored the `auth` modifier to always use `where = address(this)` and adapted errors.
 - Removed the `_auth` in `PermissionManager` that allowed for having the `ROOT_PERMISSION_ID` permission for a specific `where` target contract.
 - Removed the `WITHDRAW_PERMISSION_ID`.
 - Removed `DaoAuthorizableCloneable` and `DaoAuthorizableBase`.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Refactored the `auth` modifier to always use `where = address(this)` and adapted errors.
 - Removed the `_auth` in `PermissionManager` that allowed for having the `ROOT_PERMISSION_ID` permission for a specific `where` target contract.
 - Removed the `WITHDRAW_PERMISSION_ID`.
 - Removed `DaoAuthorizableCloneable` and `DaoAuthorizableBase`.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the `_auth` in `PermissionManager` that allowed for having the `ROOT_PERMISSION_ID` permission for a specific `where` target contract.
 - Removed the `WITHDRAW_PERMISSION_ID`.
 - Removed `DaoAuthorizableCloneable` and `DaoAuthorizableBase`.
 - Moved the array length check for the `MintSettings` from `TokenVotingSetup` into `GovernanceERC20` contract.

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -133,14 +133,12 @@ contract DAO is
 
     /// @notice Internal method authorizing the upgrade of the contract via the [upgradeabilty mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
     /// @dev The caller must have the `UPGRADE_DAO_PERMISSION_ID` permission.
-    function _authorizeUpgrade(
-        address
-    ) internal virtual override auth(address(this), UPGRADE_DAO_PERMISSION_ID) {}
+    function _authorizeUpgrade(address) internal virtual override auth(UPGRADE_DAO_PERMISSION_ID) {}
 
     /// @inheritdoc IDAO
     function setTrustedForwarder(
         address _newTrustedForwarder
-    ) external override auth(address(this), SET_TRUSTED_FORWARDER_PERMISSION_ID) {
+    ) external override auth(SET_TRUSTED_FORWARDER_PERMISSION_ID) {
         _setTrustedForwarder(_newTrustedForwarder);
     }
 
@@ -162,7 +160,7 @@ contract DAO is
     /// @inheritdoc IDAO
     function setMetadata(
         bytes calldata _metadata
-    ) external override auth(address(this), SET_METADATA_PERMISSION_ID) {
+    ) external override auth(SET_METADATA_PERMISSION_ID) {
         _setMetadata(_metadata);
     }
 
@@ -174,7 +172,7 @@ contract DAO is
     )
         external
         override
-        auth(address(this), EXECUTE_PERMISSION_ID)
+        auth(EXECUTE_PERMISSION_ID)
         returns (bytes[] memory execResults, uint256 failureMap)
     {
         if (_actions.length > MAX_ACTIONS) {
@@ -234,7 +232,7 @@ contract DAO is
     /// @inheritdoc IDAO
     function setSignatureValidator(
         address _signatureValidator
-    ) external override auth(address(this), SET_SIGNATURE_VALIDATOR_PERMISSION_ID) {
+    ) external override auth(SET_SIGNATURE_VALIDATOR_PERMISSION_ID) {
         signatureValidator = IERC1271(_signatureValidator);
 
         emit SignatureValidatorSet({signatureValidator: _signatureValidator});
@@ -306,7 +304,7 @@ contract DAO is
         bytes4 _interfaceId,
         bytes4 _callbackSelector,
         bytes4 _magicNumber
-    ) external override auth(address(this), REGISTER_STANDARD_CALLBACK_PERMISSION_ID) {
+    ) external override auth(REGISTER_STANDARD_CALLBACK_PERMISSION_ID) {
         _registerInterface(_interfaceId);
         _registerCallback(_callbackSelector, _magicNumber);
         emit StandardCallbackRegistered(_interfaceId, _callbackSelector, _magicNumber);
@@ -319,9 +317,7 @@ contract DAO is
 
     /// @notice Updates the set DAO uri to a new value.
     /// @param newDaoURI The new DAO uri to be set.
-    function setDaoURI(
-        string calldata newDaoURI
-    ) external auth(address(this), SET_METADATA_PERMISSION_ID) {
+    function setDaoURI(string calldata newDaoURI) external auth(SET_METADATA_PERMISSION_ID) {
         _setDaoURI(newDaoURI);
     }
 

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -142,10 +142,9 @@ contract PermissionManager is Initializable {
         _revoke(_where, _who, _permissionId);
     }
 
-    /// @notice Processes bulk items on the permission manager.
-    /// @dev Requires the `ROOT_PERMISSION_ID` permission.
-    /// @param _where The address of the contract.
-    /// @param items The array of bulk items to process.
+    /// @notice Applies an array of permission operations on a single target contracts `_where`.
+    /// @param _where The address of the single target contract.
+    /// @param items The array of single-targeted permission operations to apply.
     function applySingleTargetPermissions(
         address _where,
         PermissionLib.SingleTargetPermission[] calldata items
@@ -165,14 +164,13 @@ contract PermissionManager is Initializable {
         }
     }
 
-    /// @notice Processes bulk items on the permission manager.
-    /// @dev Requires that msg.sender has each permissionId on the where.
-    /// @param items The array of bulk items to process.
+    /// @notice Applies an array of permission operations on multiple target contracts `items[i].where`.
+    /// @param _items The array of multi-targeted permission operations to apply.
     function applyMultiTargetPermissions(
-        PermissionLib.MultiTargetPermission[] calldata items
+        PermissionLib.MultiTargetPermission[] calldata _items
     ) external auth(ROOT_PERMISSION_ID) {
-        for (uint256 i; i < items.length; ) {
-            PermissionLib.MultiTargetPermission memory item = items[i];
+        for (uint256 i; i < _items.length; ) {
+            PermissionLib.MultiTargetPermission memory item = _items[i];
 
             if (item.operation == PermissionLib.Operation.Grant) {
                 _grant(item.where, item.who, item.permissionId);

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -172,11 +172,9 @@ contract PermissionManager is Initializable {
     /// @param items The array of bulk items to process.
     function applyMultiTargetPermissions(
         PermissionLib.MultiTargetPermission[] calldata items
-    ) external {
+    ) external auth(address(this), ROOT_PERMISSION_ID) {
         for (uint256 i; i < items.length; ) {
             PermissionLib.MultiTargetPermission memory item = items[i];
-
-            _auth(address(this), ROOT_PERMISSION_ID);
 
             if (item.operation == PermissionLib.Operation.Grant) {
                 _grant(item.where, item.who, item.permissionId);

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -290,11 +290,11 @@ contract PermissionManager is Initializable {
         }
     }
 
-    /// @notice Checks if a caller is granted permissions on a contract via a permission identifier and redirects the approval to a `PermissionCondition` if this was specified in the setup.
+    /// @notice Checks if a caller is granted permissions on a target contract via a permission identifier and redirects the approval to a `PermissionCondition` if this was specified in the setup.
     /// @param _where The address of the target contract for which `who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
-    /// @param _data The optional data passed to the `PermissionCondition` registered..
+    /// @param _data The optional data passed to the `PermissionCondition` registered.
     /// @return bool Returns true if `who` has the permissions on the contract via the specified permissionId identifier.
     function _isGranted(
         address _where,

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -23,7 +23,7 @@ contract PermissionManager is Initializable {
     /// @notice A special address encoding if a permission is allowed.
     address internal constant ALLOW_FLAG = address(2);
 
-    /// @notice A mapping storing permissions as hashes (i.e., `permissionHash(where, who, permissionId)`) and their status (unset, allowed, or redirect to a `PermissionCondition`).
+    /// @notice A mapping storing permissions as hashes (i.e., `permissionHash(where, who, permissionId)`) and their status encoded by an address (unset, allowed, or redirecting to a `PermissionCondition`).
     mapping(bytes32 => address) internal permissionsHashed;
 
     /// @notice Thrown if a call is unauthorized.
@@ -37,7 +37,7 @@ contract PermissionManager is Initializable {
 
     /// @notice Thrown if a permission has been already granted with a different condition.
     /// @dev This makes sure that condition on the same permission can not be overwriten by a different condition.
-    /// @param where The address of the target contract to grant `who` permission to.
+    /// @param where The address of the target contract to grant `_who` permission to.
     /// @param who The address (EOA or contract) to which the permission has already been granted.
     /// @param permissionId The permission identifier.
     /// @param currentCondition The current condition set for permissionId
@@ -61,10 +61,10 @@ contract PermissionManager is Initializable {
 
     // Events
 
-    /// @notice Emitted when a permission `permission` is granted in the context `here` to the address `who` for the contract `where`.
+    /// @notice Emitted when a permission `permission` is granted in the context `here` to the address `_who` for the contract `_where`.
     /// @param permissionId The permission identifier.
     /// @param here The address of the context in which the permission is granted.
-    /// @param where The address of the target contract for which `who` receives permission.
+    /// @param where The address of the target contract for which `_who` receives permission.
     /// @param who The address (EOA or contract) receiving the permission.
     /// @param condition The address `ALLOW_FLAG` for regular permissions or, alternatively, the `PermissionCondition` to be used.
     event Granted(
@@ -75,10 +75,10 @@ contract PermissionManager is Initializable {
         IPermissionCondition condition
     );
 
-    /// @notice Emitted when a permission `permission` is revoked in the context `here` from the address `who` for the contract `where`.
+    /// @notice Emitted when a permission `permission` is revoked in the context `here` from the address `_who` for the contract `_where`.
     /// @param permissionId The permission identifier.
     /// @param here The address of the context in which the permission is revoked.
-    /// @param where The address of the target contract for which `who` loses permission
+    /// @param where The address of the target contract for which `_who` loses permission.
     /// @param who The address (EOA or contract) losing the permission.
     event Revoked(
         bytes32 indexed permissionId,
@@ -103,7 +103,7 @@ contract PermissionManager is Initializable {
 
     /// @notice Grants permission to an address to call methods in a contract guarded by an auth modifier with the specified permission identifier.
     /// @dev Requires the `ROOT_PERMISSION_ID` permission.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) receiving the permission.
     /// @param _permissionId The permission identifier.
     function grant(
@@ -116,7 +116,7 @@ contract PermissionManager is Initializable {
 
     /// @notice Grants permission to an address to call methods in a target contract guarded by an auth modifier with the specified permission identifier if the referenced condition permits it.
     /// @dev Requires the `ROOT_PERMISSION_ID` permission
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) receiving the permission.
     /// @param _permissionId The permission identifier.
     /// @param _condition The `PermissionCondition` that will be asked for authorization on calls connected to the specified permission identifier.
@@ -131,7 +131,7 @@ contract PermissionManager is Initializable {
 
     /// @notice Revokes permission from an address to call methods in a target contract guarded by an auth modifier with the specified permission identifier.
     /// @dev Requires the `ROOT_PERMISSION_ID` permission.
-    /// @param _where The address of the target contract for which `who` loses permission.
+    /// @param _where The address of the target contract for which `_who` loses permission.
     /// @param _who The address (EOA or contract) losing the permission.
     /// @param _permissionId The permission identifier.
     function revoke(
@@ -192,11 +192,11 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice Checks if an address has permission on a contract via a permission identifier and considers if `ANY_ADDRESS` was used in the granting process.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) for which the permission is checked.
     /// @param _permissionId The permission identifier.
     /// @param _data The optional data passed to the `PermissionCondition` registered.
-    /// @return bool Returns true if `who` has the permissions on the target contract via the specified permission identifier.
+    /// @return bool Returns true if `_who` has the permissions on the target contract via the specified permission identifier.
     function isGranted(
         address _where,
         address _who,
@@ -204,9 +204,9 @@ contract PermissionManager is Initializable {
         bytes memory _data
     ) public view returns (bool) {
         return
-            _isGranted(_where, _who, _permissionId, _data) || // check if _who has permission for _permissionId on _where
-            _isGranted(_where, ANY_ADDR, _permissionId, _data) || // check if anyone has permission for _permissionId on _where
-            _isGranted(ANY_ADDR, _who, _permissionId, _data); // check if _who has permission for _permissionId on any contract
+            _isGranted(_where, _who, _permissionId, _data) || // check if `_who` has permission for `_permissionId` on `_where`
+            _isGranted(_where, ANY_ADDR, _permissionId, _data) || // check if anyone has permission for `_permissionId` on `_where`
+            _isGranted(ANY_ADDR, _who, _permissionId, _data); // check if `_who` has permission for `_permissionI` on any contract
     }
 
     /// @notice Grants the `ROOT_PERMISSION_ID` permission to the initial owner during initialization of the permission manager.
@@ -216,7 +216,7 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice This method is used in the public `grant` method of the permission manager.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
     function _grant(address _where, address _who, bytes32 _permissionId) internal {
@@ -224,10 +224,10 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice This method is used in the internal `_grant` method of the permission manager.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
-    /// @param _condition The PermissionCondition to be used or it is just the ALLOW_FLAG.
+    /// @param _condition An address either resolving to a `PermissionCondition` contract address or being the `ALLOW_FLAG` address (`address(2)`).
     function _grantWithCondition(
         address _where,
         address _who,
@@ -260,7 +260,7 @@ contract PermissionManager is Initializable {
 
             emit Granted(_permissionId, msg.sender, _where, _who, _condition);
         } else if (currentCondition != newCondition) {
-            // Revert if the permHash is already granted, but uses a different condition.
+            // Revert if `permHash` is already granted, but uses a different condition.
             // If we don't revert, we either should:
             //   - allow overriding the condition on the same permission
             //     which could be confusing whoever granted the same permission first
@@ -276,7 +276,7 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice This method is used in the public `revoke` method of the permission manager.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
     function _revoke(address _where, address _who, bytes32 _permissionId) internal {
@@ -289,11 +289,11 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice Checks if a caller is granted permissions on a target contract via a permission identifier and redirects the approval to a `PermissionCondition` if this was specified in the setup.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
     /// @param _data The optional data passed to the `PermissionCondition` registered.
-    /// @return bool Returns true if `who` has the permissions on the contract via the specified permissionId identifier.
+    /// @return bool Returns true if `_who` has the permissions on the contract via the specified permissionId identifier.
     function _isGranted(
         address _where,
         address _who,
@@ -322,7 +322,7 @@ contract PermissionManager is Initializable {
         return false;
     }
 
-    /// @notice A private function to be used to check permissions on a target contract.
+    /// @notice A private function to be used to check permissions on the permission manager contract (`address(this)`) itself.
     /// @param _permissionId The permission identifier required to call the method this modifier is applied to.
     function _auth(bytes32 _permissionId) private view {
         if (!isGranted(address(this), msg.sender, _permissionId, msg.data)) {
@@ -335,7 +335,7 @@ contract PermissionManager is Initializable {
     }
 
     /// @notice Generates the hash for the `permissionsHashed` mapping obtained from the word "PERMISSION", the contract address, the address owning the permission, and the permission identifier.
-    /// @param _where The address of the target contract for which `who` recieves permission.
+    /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
     /// @return bytes32 The permission hash.

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -112,7 +112,7 @@ contract PermissionManager is Initializable {
         address _where,
         address _who,
         bytes32 _permissionId
-    ) external auth(_where, ROOT_PERMISSION_ID) {
+    ) external auth(address(this), ROOT_PERMISSION_ID) {
         _grant(_where, _who, _permissionId);
     }
 
@@ -127,7 +127,7 @@ contract PermissionManager is Initializable {
         address _who,
         bytes32 _permissionId,
         IPermissionCondition _condition
-    ) external auth(_where, ROOT_PERMISSION_ID) {
+    ) external auth(address(this), ROOT_PERMISSION_ID) {
         _grantWithCondition(_where, _who, _permissionId, _condition);
     }
 
@@ -140,7 +140,7 @@ contract PermissionManager is Initializable {
         address _where,
         address _who,
         bytes32 _permissionId
-    ) external auth(_where, ROOT_PERMISSION_ID) {
+    ) external auth(address(this), ROOT_PERMISSION_ID) {
         _revoke(_where, _who, _permissionId);
     }
 
@@ -151,7 +151,7 @@ contract PermissionManager is Initializable {
     function applySingleTargetPermissions(
         address _where,
         PermissionLib.SingleTargetPermission[] calldata items
-    ) external auth(_where, ROOT_PERMISSION_ID) {
+    ) external auth(address(this), ROOT_PERMISSION_ID) {
         for (uint256 i; i < items.length; ) {
             PermissionLib.SingleTargetPermission memory item = items[i];
 
@@ -176,7 +176,7 @@ contract PermissionManager is Initializable {
         for (uint256 i; i < items.length; ) {
             PermissionLib.MultiTargetPermission memory item = items[i];
 
-            _auth(item.where, ROOT_PERMISSION_ID);
+            _auth(address(this), ROOT_PERMISSION_ID);
 
             if (item.operation == PermissionLib.Operation.Grant) {
                 _grant(item.where, item.who, item.permissionId);
@@ -332,10 +332,7 @@ contract PermissionManager is Initializable {
     /// @param _where The address of the target contract for which the permission is required.
     /// @param _permissionId The permission identifier required to call the method this modifier is applied to.
     function _auth(address _where, bytes32 _permissionId) private view {
-        if (
-            !isGranted(address(this), msg.sender, _permissionId, msg.data) &&
-            !isGranted(_where, msg.sender, _permissionId, msg.data)
-        ) {
+        if (!isGranted(_where, msg.sender, _permissionId, msg.data)) {
             revert Unauthorized({
                 here: address(this),
                 where: _where,

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -87,7 +87,7 @@ contract PermissionManager is Initializable {
         address indexed who
     );
 
-    /// @notice A modifier to be used to check permissions on a target contract.
+    /// @notice A modifier to make functions on inheriting contracts authorized. Permissions to call the function are checked through this permission manager.
     /// @param _permissionId The permission identifier required to call the method this modifier is applied to.
     modifier auth(bytes32 _permissionId) {
         _auth(_permissionId);

--- a/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizable.sol
+++ b/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizable.sol
@@ -26,7 +26,7 @@ abstract contract DaoAuthorizable is Context {
         return dao_;
     }
 
-    /// @notice A modifier to be used to check permissions on a target contract via the associated DAO.
+    /// @notice A modifier to make functions on inheriting contracts authorized. Permissions to call the function are checked through the associated DAO's permission manager.
     /// @param _permissionId The permission identifier required to call the method this modifier is applied to.
     modifier auth(bytes32 _permissionId) {
         _auth(dao_, address(this), _msgSender(), _permissionId, _msgData());

--- a/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizableUpgradeable.sol
+++ b/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizableUpgradeable.sol
@@ -27,7 +27,7 @@ abstract contract DaoAuthorizableUpgradeable is ContextUpgradeable {
         return dao_;
     }
 
-    /// @notice A modifier to be used to check permissions on a target contract via the associated DAO.
+    /// @notice A modifier to make functions on inheriting contracts authorized. Permissions to call the function are checked through the associated DAO's permission manager.
     /// @param _permissionId The permission identifier required to call the method this modifier is applied to.
     modifier auth(bytes32 _permissionId) {
         _auth(dao_, address(this), _msgSender(), _permissionId, _msgData());

--- a/packages/contracts/src/core/utils/auth.sol
+++ b/packages/contracts/src/core/utils/auth.sol
@@ -11,20 +11,23 @@ import {IDAO} from "../dao/IDAO.sol";
 /// @param permissionId The permission identifier.
 error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId);
 
-/// @notice Free function to to be used by the auth modifier to check permissions on a target contract via the associated DAO.
+/// @notice A free function checking if a caller is granted permissions on a target contract via a permission identifier that redirects the approval to a `PermissionCondition` if this was specified in the setup.
+/// @param _where The address of the target contract for which `who` recieves permission.
+/// @param _who The address (EOA or contract) owning the permission.
 /// @param _permissionId The permission identifier.
+/// @param _data The optional data passed to the `PermissionCondition` registered.
 function _auth(
     IDAO _dao,
-    address _addressThis,
-    address _msgSender,
+    address _where,
+    address _who,
     bytes32 _permissionId,
-    bytes calldata _msgData
+    bytes calldata _data
 ) view {
-    if (!_dao.hasPermission(_addressThis, _msgSender, _permissionId, _msgData))
+    if (!_dao.hasPermission(_where, _who, _permissionId, _data))
         revert DaoUnauthorized({
             dao: address(_dao),
-            where: _addressThis,
-            who: _msgSender,
+            where: _where,
+            who: _who,
             permissionId: _permissionId
         });
 }

--- a/packages/contracts/src/core/utils/auth.sol
+++ b/packages/contracts/src/core/utils/auth.sol
@@ -6,26 +6,24 @@ import {IDAO} from "../dao/IDAO.sol";
 
 /// @notice Thrown if a call is unauthorized in the associated DAO.
 /// @param dao The associated DAO.
-/// @param here The context in which the authorization reverted.
-/// @param where The contract requiring the permission.
+/// @param where The context in which the authorization reverted.
 /// @param who The address (EOA or contract) missing the permission.
 /// @param permissionId The permission identifier.
-error DaoUnauthorized(address dao, address here, address where, address who, bytes32 permissionId);
+error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId);
 
 /// @notice Free function to to be used by the auth modifier to check permissions on a target contract via the associated DAO.
 /// @param _permissionId The permission identifier.
 function _auth(
     IDAO _dao,
-    address addressThis,
+    address _addressThis,
     address _msgSender,
     bytes32 _permissionId,
     bytes calldata _msgData
 ) view {
-    if (!_dao.hasPermission(addressThis, _msgSender, _permissionId, _msgData))
+    if (!_dao.hasPermission(_addressThis, _msgSender, _permissionId, _msgData))
         revert DaoUnauthorized({
             dao: address(_dao),
-            here: addressThis,
-            where: addressThis,
+            where: _addressThis,
             who: _msgSender,
             permissionId: _permissionId
         });

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -129,7 +129,7 @@ contract PluginRepo is
         address _pluginSetup,
         bytes calldata _buildMetadata,
         bytes calldata _releaseMetadata
-    ) external auth(address(this), MAINTAINER_PERMISSION_ID) {
+    ) external auth(MAINTAINER_PERMISSION_ID) {
         if (!_pluginSetup.supportsInterface(type(IPluginSetup).interfaceId)) {
             revert InvalidPluginSetupInterface();
         }
@@ -186,7 +186,7 @@ contract PluginRepo is
     function updateReleaseMetadata(
         uint8 _release,
         bytes calldata _releaseMetadata
-    ) external auth(address(this), MAINTAINER_PERMISSION_ID) {
+    ) external auth(MAINTAINER_PERMISSION_ID) {
         if (_release == 0) {
             revert ReleaseZeroNotAllowed();
         }
@@ -255,7 +255,7 @@ contract PluginRepo is
     /// @dev The caller must have the `UPGRADE_REPO_PERMISSION_ID` permission.
     function _authorizeUpgrade(
         address
-    ) internal virtual override auth(address(this), UPGRADE_REPO_PERMISSION_ID) {}
+    ) internal virtual override auth(UPGRADE_REPO_PERMISSION_ID) {}
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param interfaceId The ID of the interface.

--- a/packages/contracts/src/test/plugin/SharedPluginTest.sol
+++ b/packages/contracts/src/test/plugin/SharedPluginTest.sol
@@ -28,7 +28,6 @@ contract TestSharedPlugin is PluginUUPSUpgradeable {
         if (!ownedIds[_id].hasPermission(address(this), _msgSender(), _permissionId, _msgData())) {
             revert DaoUnauthorized({
                 dao: address(dao()),
-                here: address(this),
                 where: address(this),
                 who: _msgSender(),
                 permissionId: _permissionId

--- a/packages/contracts/test/core/dao/dao.ts
+++ b/packages/contracts/test/core/dao/dao.ts
@@ -194,7 +194,6 @@ describe('DAO', function () {
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
           dao.address,
-          dao.address,
           ownerAddress,
           PERMISSION_IDS.SET_TRUSTED_FORWARDER_PERMISSION_ID
         );
@@ -224,7 +223,6 @@ describe('DAO', function () {
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
           dao.address,
-          dao.address,
           ownerAddress,
           PERMISSION_IDS.SET_METADATA_PERMISSION_ID
         );
@@ -253,7 +251,6 @@ describe('DAO', function () {
       await expect(dao.execute(ZERO_BYTES32, [data.succeedAction], 0))
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
-          dao.address,
           dao.address,
           ownerAddress,
           PERMISSION_IDS.EXECUTE_PERMISSION_ID
@@ -770,7 +767,6 @@ describe('DAO', function () {
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
           dao.address,
-          dao.address,
           ownerAddress,
           PERMISSION_IDS.REGISTER_STANDARD_CALLBACK_PERMISSION_ID
         );
@@ -854,7 +850,6 @@ describe('DAO', function () {
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
           dao.address,
-          dao.address,
           signers[2].address,
           PERMISSION_IDS.SET_SIGNATURE_VALIDATOR_PERMISSION_ID
         );
@@ -915,7 +910,6 @@ describe('DAO', function () {
         await expect(dao.setDaoURI('https://new.example.com'))
           .to.be.revertedWithCustomError(dao, 'Unauthorized')
           .withArgs(
-            dao.address,
             dao.address,
             ownerAddress,
             PERMISSION_IDS.SET_METADATA_PERMISSION_ID

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -151,12 +151,7 @@ describe('Core: PermissionManager', function () {
           .grant(pm.address, otherSigner.address, ADMIN_PERMISSION_ID)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
     it('should not allow for non ROOT', async () => {
@@ -167,12 +162,7 @@ describe('Core: PermissionManager', function () {
           .grant(pm.address, otherSigner.address, ROOT_PERMISSION_ID)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
   });
 
@@ -310,12 +300,7 @@ describe('Core: PermissionManager', function () {
           )
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
     it('should not allow for non ROOT', async () => {
@@ -336,12 +321,7 @@ describe('Core: PermissionManager', function () {
           )
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
   });
 
@@ -372,12 +352,7 @@ describe('Core: PermissionManager', function () {
           .revoke(pm.address, otherSigner.address, ADMIN_PERMISSION_ID)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
     it('should not emit revoked if already revoked', async () => {
@@ -395,12 +370,7 @@ describe('Core: PermissionManager', function () {
           .revoke(pm.address, otherSigner.address, ADMIN_PERMISSION_ID)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
     it('should not allow for non ROOT', async () => {
@@ -411,12 +381,7 @@ describe('Core: PermissionManager', function () {
           .revoke(pm.address, otherSigner.address, ADMIN_PERMISSION_ID)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
   });
 
@@ -537,12 +502,7 @@ describe('Core: PermissionManager', function () {
         pm.connect(signers[2]).applyMultiTargetPermissions(bulkItems)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          signers[2].address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, signers[2].address, ROOT_PERMISSION_ID);
     });
   });
 
@@ -698,12 +658,7 @@ describe('Core: PermissionManager', function () {
           .applySingleTargetPermissions(pm.address, bulkItems)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
     it('should not allow for non ROOT', async () => {
@@ -721,12 +676,7 @@ describe('Core: PermissionManager', function () {
           .applySingleTargetPermissions(pm.address, bulkItems)
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
-        .withArgs(
-          pm.address,
-          pm.address,
-          otherSigner.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
   });
 

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -539,7 +539,7 @@ describe('Core: PermissionManager', function () {
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
         .withArgs(
           pm.address,
-          signers[1].address,
+          pm.address,
           signers[2].address,
           ROOT_PERMISSION_ID
         );

--- a/packages/contracts/test/core/plugin/parameter-scoping-condition.ts
+++ b/packages/contracts/test/core/plugin/parameter-scoping-condition.ts
@@ -48,7 +48,6 @@ describe('TestParameterScopingCondition', function () {
     expectedUnauthorizedErrorArguments = [
       managingDao.address,
       testPlugin.address,
-      testPlugin.address,
       ownerAddress,
       DO_SOMETHING_PERMISSION_ID,
     ];

--- a/packages/contracts/test/core/plugin/shared-plugin.ts
+++ b/packages/contracts/test/core/plugin/shared-plugin.ts
@@ -38,7 +38,6 @@ describe('SharedPlugin', function () {
     expectedUnauthorizedErrorArguments = [
       managingDao.address,
       testPlugin.address,
-      testPlugin.address,
       ownerAddress,
       ID_GATED_ACTION_PERMISSION_ID,
     ];

--- a/packages/contracts/test/framework/dao/dao-registry.ts
+++ b/packages/contracts/test/framework/dao/dao-registry.ts
@@ -128,7 +128,6 @@ describe('DAORegistry', function () {
       .withArgs(
         managingDao.address,
         daoRegistry.address,
-        daoRegistry.address,
         ownerAddress,
         REGISTER_DAO_PERMISSION_ID
       );

--- a/packages/contracts/test/framework/plugin/plugin-repo-factory.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo-factory.ts
@@ -120,7 +120,6 @@ describe('PluginRepoFactory: ', function () {
       .withArgs(
         managingDao.address,
         pluginRepoRegistry.address,
-        pluginRepoRegistry.address,
         pluginRepoFactory.address,
         REGISTER_PLUGIN_REPO_PERMISSION_ID
       );

--- a/packages/contracts/test/framework/plugin/plugin-repo-registry.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo-registry.ts
@@ -141,7 +141,6 @@ describe('PluginRepoRegistry', function () {
       .withArgs(
         managingDAO.address,
         pluginRepoRegistry.address,
-        pluginRepoRegistry.address,
         ownerAddress,
         REGISTER_PLUGIN_REPO_PERMISSION_ID
       );

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -60,7 +60,6 @@ describe('PluginRepo', function () {
         .to.be.revertedWithCustomError(pluginRepo, 'Unauthorized')
         .withArgs(
           pluginRepo.address,
-          pluginRepo.address,
           signers[2].address,
           MAINTAINER_PERMISSION_ID
         );
@@ -293,7 +292,6 @@ describe('PluginRepo', function () {
       )
         .to.be.revertedWithCustomError(pluginRepo, 'Unauthorized')
         .withArgs(
-          pluginRepo.address,
           pluginRepo.address,
           signers[2].address,
           MAINTAINER_PERMISSION_ID

--- a/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
+++ b/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
@@ -529,12 +529,7 @@ describe('Plugin Setup Processor', function () {
           )
         )
           .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
-          .withArgs(
-            targetDao.address,
-            targetDao.address,
-            psp.address,
-            ROOT_PERMISSION_ID
-          );
+          .withArgs(targetDao.address, psp.address, ROOT_PERMISSION_ID);
       });
 
       it("reverts if setupId wasn't prepared by `prepareInstallation` first", async () => {
@@ -1076,12 +1071,7 @@ describe('Plugin Setup Processor', function () {
           )
         )
           .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
-          .withArgs(
-            targetDao.address,
-            targetDao.address,
-            psp.address,
-            ROOT_PERMISSION_ID
-          );
+          .withArgs(targetDao.address, psp.address, ROOT_PERMISSION_ID);
       });
 
       it('reverts if uninstallation is not prepared first', async () => {
@@ -1687,12 +1677,7 @@ describe('Plugin Setup Processor', function () {
         )
       )
         .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
-        .withArgs(
-          targetDao.address,
-          targetDao.address,
-          psp.address,
-          ROOT_PERMISSION_ID
-        );
+        .withArgs(targetDao.address, psp.address, ROOT_PERMISSION_ID);
     });
 
     it('reverts if the plugin setup processor does not have the `UPGRADE_PLUGIN_PERMISSION_ID` permission', async () => {

--- a/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
+++ b/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
@@ -531,7 +531,7 @@ describe('Plugin Setup Processor', function () {
           .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
           .withArgs(
             targetDao.address,
-            permissions[0]['where'],
+            targetDao.address,
             psp.address,
             ROOT_PERMISSION_ID
           );
@@ -1078,7 +1078,7 @@ describe('Plugin Setup Processor', function () {
           .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
           .withArgs(
             targetDao.address,
-            permissions[0]['where'],
+            targetDao.address,
             psp.address,
             ROOT_PERMISSION_ID
           );
@@ -1689,7 +1689,7 @@ describe('Plugin Setup Processor', function () {
         .to.be.revertedWithCustomError(targetDao, 'Unauthorized')
         .withArgs(
           targetDao.address,
-          permissions[0]['where'],
+          targetDao.address,
           psp.address,
           ROOT_PERMISSION_ID
         );

--- a/packages/contracts/test/framework/utils/ens/ens-subdomain-registry.ts
+++ b/packages/contracts/test/framework/utils/ens/ens-subdomain-registry.ts
@@ -362,7 +362,6 @@ describe('ENSSubdomainRegistrar', function () {
           .withArgs(
             managingDao.address,
             registrar.address,
-            registrar.address,
             signers[1].address,
             REGISTER_ENS_SUBDOMAIN_PERMISSION_ID
           );
@@ -378,7 +377,6 @@ describe('ENSSubdomainRegistrar', function () {
           .to.be.revertedWithCustomError(registrar, 'DaoUnauthorized')
           .withArgs(
             managingDao.address,
-            registrar.address,
             registrar.address,
             signers[1].address,
             REGISTER_ENS_SUBDOMAIN_PERMISSION_ID

--- a/packages/contracts/test/framework/utils/interface-based-registry.ts
+++ b/packages/contracts/test/framework/utils/interface-based-registry.ts
@@ -88,7 +88,6 @@ describe('InterfaceBasedRegistry', function () {
         .withArgs(
           dao.address,
           interfaceBasedRegistryMock.address,
-          interfaceBasedRegistryMock.address,
           ownerAddress,
           REGISTER_PERMISSION_ID
         );

--- a/packages/contracts/test/plugins/governance/admin/admin.ts
+++ b/packages/contracts/test/plugins/governance/admin/admin.ts
@@ -129,12 +129,7 @@ describe('Admin plugin', function () {
 
       await expect(plugin.executeProposal(dummyMetadata, dummyActions, 0))
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
-        .withArgs(
-          dao.address,
-          dao.address,
-          plugin.address,
-          EXECUTE_PERMISSION_ID
-        );
+        .withArgs(dao.address, plugin.address, EXECUTE_PERMISSION_ID);
     });
 
     it('fails to call `executeProposal()` if `EXECUTE_PROPOSAL_PERMISSION_ID` is not granted for the admin address', async () => {
@@ -148,7 +143,6 @@ describe('Admin plugin', function () {
         .to.be.revertedWithCustomError(plugin, 'DaoUnauthorized')
         .withArgs(
           dao.address,
-          plugin.address,
           plugin.address,
           ownerAddress,
           EXECUTE_PROPOSAL_PERMISSION_ID

--- a/packages/contracts/test/plugins/token/distribution/merkle-minter.ts
+++ b/packages/contracts/test/plugins/token/distribution/merkle-minter.ts
@@ -138,7 +138,6 @@ describe('MerkleMinter', function () {
         .withArgs(
           managingDao.address,
           minter.address,
-          minter.address,
           ownerAddress,
           MERKLE_MINT_PERMISSION_ID
         );
@@ -162,7 +161,6 @@ describe('MerkleMinter', function () {
         .to.be.revertedWithCustomError(minter, 'DaoUnauthorized')
         .withArgs(
           managingDao.address,
-          token.address,
           token.address,
           minter.address,
           MINT_PERMISSION_ID

--- a/packages/contracts/test/test-utils/uups-upgradeable.ts
+++ b/packages/contracts/test/test-utils/uups-upgradeable.ts
@@ -1,6 +1,6 @@
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
-import {Contract, Signer} from 'ethers';
+import {Contract} from 'ethers';
 import {ethers} from 'hardhat';
 
 /// Used as a common test suite to test upgradeability of the contracts.
@@ -20,21 +20,11 @@ export function shouldUpgradeCorrectly(
     user: SignerWithAddress,
     dao: Contract
   ) {
-    return [
-      dao.address,
-      contract.address,
-      contract.address,
-      user.address,
-      upgradePermissionId,
-    ];
+    return [dao.address, contract.address, user.address, upgradePermissionId];
   }
 
-  function UnauthorizedRevertArgs(
-    contract: Contract,
-    user: SignerWithAddress,
-    dao: Contract
-  ) {
-    return [dao.address, contract.address, user.address, upgradePermissionId];
+  function UnauthorizedRevertArgs(contract: Contract, user: SignerWithAddress) {
+    return [contract.address, user.address, upgradePermissionId];
   }
 
   describe('UUPS Upgradeability Test', async () => {
@@ -69,13 +59,13 @@ export function shouldUpgradeCorrectly(
             contract,
             upgradeRevertPermissionMessage
           )
-          .withArgs(...UnauthorizedRevertArgs(contract, user, dao));
+          .withArgs(...UnauthorizedRevertArgs(contract, user));
         await expect(tx2)
           .to.be.revertedWithCustomError(
             contract,
             upgradeRevertPermissionMessage
           )
-          .withArgs(...UnauthorizedRevertArgs(contract, user, dao));
+          .withArgs(...UnauthorizedRevertArgs(contract, user));
       }
     });
 

--- a/packages/contracts/test/test-utils/uups-upgradeable.ts
+++ b/packages/contracts/test/test-utils/uups-upgradeable.ts
@@ -23,11 +23,11 @@ export function shouldUpgradeCorrectly(
     return [dao.address, contract.address, user.address, upgradePermissionId];
   }
 
-  function UnauthorizedRevertArgs(contract: Contract, user: SignerWithAddress) {
-    return [contract.address, user.address, upgradePermissionId];
+  function UnauthorizedRevertArgs(dao: Contract, user: SignerWithAddress) {
+    return [dao.address, user.address, upgradePermissionId];
   }
 
-  describe('UUPS Upgradeability Test', async () => {
+  describe.only('UUPS Upgradeability Test', async () => {
     before(async () => {
       const factory = await ethers.getContractFactory(
         'PluginUUPSUpgradeableV1Mock'
@@ -59,13 +59,13 @@ export function shouldUpgradeCorrectly(
             contract,
             upgradeRevertPermissionMessage
           )
-          .withArgs(...UnauthorizedRevertArgs(contract, user));
+          .withArgs(...UnauthorizedRevertArgs(dao, user));
         await expect(tx2)
           .to.be.revertedWithCustomError(
             contract,
             upgradeRevertPermissionMessage
           )
-          .withArgs(...UnauthorizedRevertArgs(contract, user));
+          .withArgs(...UnauthorizedRevertArgs(dao, user));
       }
     });
 

--- a/packages/contracts/test/test-utils/uups-upgradeable.ts
+++ b/packages/contracts/test/test-utils/uups-upgradeable.ts
@@ -27,7 +27,7 @@ export function shouldUpgradeCorrectly(
     return [dao.address, user.address, upgradePermissionId];
   }
 
-  describe.only('UUPS Upgradeability Test', async () => {
+  describe('UUPS Upgradeability Test', async () => {
     before(async () => {
       const factory = await ethers.getContractFactory(
         'PluginUUPSUpgradeableV1Mock'

--- a/packages/contracts/test/token/erc20/governance-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-erc20.ts
@@ -119,7 +119,6 @@ describe('GovernanceERC20', function () {
         .withArgs(
           dao.address,
           token.address,
-          token.address,
           signers[0].address,
           MINT_PERMISSION_ID
         );


### PR DESCRIPTION
## Description
Remove`PermissionManager` feature that allowed for having the `ROOT_PERMISSION_ID` permission for a specific `where` target contract and simplified `auth` in `PermissionManager` by always setting `where = address(this)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.