### PR TITLE
Moves `_disableInitializers` inside `PluginCloneable` and `PluginUUPSUpgradeable`

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved `_disableInitializers` inside the constructors of `PluginCloneable` and `PluginUUPSUpgradeable`.
 - Renamed `DAOSettings.name` to `DAOSettings.subdomain`.
 - Fixed the ERC165 interface ID and `supportsInterface` computations.
 - Replaced non-upgradeable contract dependencies by upgradeable ones for the cloneable `Admin` plugin.

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -88,7 +88,7 @@ contract DAO is
     /// @param daoURI The new uri.
     event NewURI(string daoURI);
 
-    /// @dev Used to disallow initializing implementation contract by attacker for extra safety.
+    /// @notice Disables the initializers on the implementation contract to prevent it from being left uninitialized.
     constructor() {
         _disableInitializers();
     }

--- a/packages/contracts/src/core/plugin/PluginCloneable.sol
+++ b/packages/contracts/src/core/plugin/PluginCloneable.sol
@@ -12,6 +12,11 @@ import {IPlugin} from "./IPlugin.sol";
 /// @author Aragon Association - 2022-2023
 /// @notice An abstract, non-upgradeable contract to inherit from when creating a plugin being deployed via the minimal clones pattern (see [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167)).
 abstract contract PluginCloneable is IPlugin, ERC165Upgradeable, DaoAuthorizableUpgradeable {
+    /// @notice Disables the initializers on the implementation contract to prevent it from being left uninitialized.
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Initializes the plugin by storing the associated DAO.
     /// @param _dao The DAO contract.
     function __PluginCloneable_init(IDAO _dao) internal virtual onlyInitializing {

--- a/packages/contracts/src/core/plugin/PluginUUPSUpgradeable.sol
+++ b/packages/contracts/src/core/plugin/PluginUUPSUpgradeable.sol
@@ -21,6 +21,11 @@ abstract contract PluginUUPSUpgradeable is
 {
     // NOTE: When adding new state variables to the contract, the size of `_gap` has to be adapted below as well.
 
+    /// @notice Disables the initializers on the implementation contract to prevent it from being left uninitialized.
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @inheritdoc IPlugin
     function pluginType() public pure override returns (PluginType) {
         return PluginType.UUPS;

--- a/packages/contracts/src/plugins/counter-example/MultiplyHelper.sol
+++ b/packages/contracts/src/plugins/counter-example/MultiplyHelper.sol
@@ -11,11 +11,6 @@ contract MultiplyHelper is PluginUUPSUpgradeable {
     /// @notice The ID of the permission required to call the `multiply` function.
     bytes32 public constant MULTIPLY_PERMISSION_ID = keccak256("MULTIPLY_PERMISSION");
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Multiplies the count with a number.
     /// @param _a The number to multiply the coun with.
     function multiply(

--- a/packages/contracts/src/plugins/counter-example/v1/CounterV1.sol
+++ b/packages/contracts/src/plugins/counter-example/v1/CounterV1.sol
@@ -19,11 +19,6 @@ contract CounterV1 is PluginUUPSUpgradeable {
     /// @notice A helper contract associated with the plugin.
     MultiplyHelper public multiplyHelper;
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the plugin.
     /// @param _dao The contract of the associated DAO.
     /// @param _multiplyHelper The helper contract associated with the plugin to multiply numbers.

--- a/packages/contracts/src/plugins/counter-example/v2/CounterV2.sol
+++ b/packages/contracts/src/plugins/counter-example/v2/CounterV2.sol
@@ -23,11 +23,6 @@ contract CounterV2 is PluginUUPSUpgradeable {
     /// @dev By appending a new variable, the existing storage gets modified.
     uint256 public newVariable;
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the plugin.
     /// @param _dao The contract of the associated DAO.
     /// @param _multiplyHelper The helper contract associated with the plugin to multiply numbers.

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
@@ -27,11 +27,6 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
     bytes32 public constant UPDATE_ADDRESSES_PERMISSION_ID =
         keccak256("UPDATE_ADDRESSES_PERMISSION");
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.

--- a/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
@@ -28,11 +28,6 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @notice Thrown if the voting power is zero
     error NoVotingPower();
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.

--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -118,11 +118,6 @@ contract Multisig is
     /// @param minApprovals The minimum amount of approvals needed to pass a proposal.
     event MultisigSettingsUpdated(bool onlyListed, uint16 indexed minApprovals);
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the component.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.

--- a/packages/contracts/src/plugins/token/MerkleDistributor.sol
+++ b/packages/contracts/src/plugins/token/MerkleDistributor.sol
@@ -38,11 +38,6 @@ contract MerkleDistributor is IMerkleDistributor, PluginUUPSUpgradeable {
     /// @param amount The amount to be claimed.
     error TokenClaimInvalid(uint256 index, address to, uint256 amount);
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the plugin.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.

--- a/packages/contracts/src/plugins/token/MerkleMinter.sol
+++ b/packages/contracts/src/plugins/token/MerkleMinter.sol
@@ -33,11 +33,6 @@ contract MerkleMinter is IMerkleMinter, PluginUUPSUpgradeable {
     /// @inheritdoc IMerkleMinter
     IMerkleDistributor public override distributorBase;
 
-    /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Initializes the MerkleMinter.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
     /// @param _dao The IDAO interface of the associated DAO.

--- a/packages/contracts/src/test/plugin/AdminCloneFactory.sol
+++ b/packages/contracts/src/test/plugin/AdminCloneFactory.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
-import {Admin} from "../../plugins/governance//admin/Admin.sol";
+import {Admin} from "../../plugins/governance/admin/Admin.sol";
 
 contract AdminCloneFactory {
     using Clones for address;

--- a/packages/contracts/src/test/plugin/AdminCloneFactory.sol
+++ b/packages/contracts/src/test/plugin/AdminCloneFactory.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {Admin} from "../../plugins/governance//admin/Admin.sol";
+
+contract AdminCloneFactory {
+    using Clones for address;
+
+    address private immutable implementation;
+
+    constructor() {
+        implementation = address(new Admin());
+    }
+
+    function deployClone() external returns (address clone) {
+        return implementation.clone();
+    }
+}

--- a/packages/contracts/test/core/plugin/parameter-scoping-condition.ts
+++ b/packages/contracts/test/core/plugin/parameter-scoping-condition.ts
@@ -8,6 +8,7 @@ import {
   DAO,
 } from '../../../typechain';
 import {deployNewDAO} from '../../test-utils/dao';
+import {deployWithProxy} from '../../test-utils/proxy';
 
 const DO_SOMETHING_PERMISSION_ID = ethers.utils.id('DO_SOMETHING_PERMISSION');
 
@@ -28,7 +29,8 @@ describe('TestParameterScopingCondition', function () {
 
     // Deploy the component
     const TestPlugin = await ethers.getContractFactory('TestPlugin');
-    testPlugin = await TestPlugin.deploy();
+
+    testPlugin = await deployWithProxy(TestPlugin);
     await testPlugin.initialize(managingDao.address);
 
     // Deploy the condition

--- a/packages/contracts/test/core/plugin/shared-plugin.ts
+++ b/packages/contracts/test/core/plugin/shared-plugin.ts
@@ -4,6 +4,7 @@ import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
 import {TestSharedPlugin, TestIdGatingCondition, DAO} from '../../../typechain';
 import {deployNewDAO} from '../../test-utils/dao';
+import {deployWithProxy} from '../../test-utils/proxy';
 
 const ID_GATED_ACTION_PERMISSION_ID = ethers.utils.id(
   'ID_GATED_ACTION_PERMISSION'
@@ -32,7 +33,7 @@ describe('SharedPlugin', function () {
     const TestSharedPlugin = await ethers.getContractFactory(
       'TestSharedPlugin'
     );
-    testPlugin = await TestSharedPlugin.deploy();
+    testPlugin = await deployWithProxy(TestSharedPlugin);
     await testPlugin.initialize(managingDao.address);
 
     expectedUnauthorizedErrorArguments = [

--- a/packages/contracts/test/plugins/governance/admin/admin.ts
+++ b/packages/contracts/test/plugins/governance/admin/admin.ts
@@ -14,6 +14,7 @@ import {getInterfaceID} from '../../../test-utils/interfaces';
 import {OZ_ERRORS} from '../../../test-utils/error';
 import {toBytes32} from '../../../test-utils/voting';
 import {
+  AdminCloneFactory,
   IERC165Upgradeable__factory,
   IMembership__factory,
   IPlugin__factory,
@@ -34,6 +35,7 @@ export const adminInterface = new ethers.utils.Interface([
 describe('Admin', function () {
   let signers: SignerWithAddress[];
   let plugin: any;
+  let adminCloneFactory: AdminCloneFactory;
   let dao: any;
   let ownerAddress: string;
   let dummyActions: any;
@@ -65,6 +67,11 @@ describe('Admin', function () {
     );
 
     dao = await deployNewDAO(ownerAddress);
+
+    const AdminCloneFactory = await ethers.getContractFactory(
+      'AdminCloneFactory'
+    );
+    adminCloneFactory = await AdminCloneFactory.deploy();
   });
 
   beforeEach(async () => {
@@ -73,7 +80,17 @@ describe('Admin', function () {
       adminFactoryBytecode,
       signers[0]
     );
-    plugin = await deployWithProxy(AdminFactory);
+
+    const nonce = await ethers.provider.getTransactionCount(
+      adminCloneFactory.address
+    );
+    const anticipatedPluginAddress = ethers.utils.getContractAddress({
+      from: adminCloneFactory.address,
+      nonce,
+    });
+
+    await adminCloneFactory.deployClone();
+    plugin = AdminFactory.attach(anticipatedPluginAddress);
 
     await dao.grant(dao.address, plugin.address, EXECUTE_PERMISSION_ID);
     await dao.grant(

--- a/packages/contracts/test/plugins/governance/admin/admin.ts
+++ b/packages/contracts/test/plugins/governance/admin/admin.ts
@@ -73,7 +73,7 @@ describe('Admin', function () {
       adminFactoryBytecode,
       signers[0]
     );
-    plugin = await AdminFactory.deploy();
+    plugin = await deployWithProxy(AdminFactory);
 
     await dao.grant(dao.address, plugin.address, EXECUTE_PERMISSION_ID);
     await dao.grant(

--- a/packages/contracts/test/plugins/governance/majority-voting/majority-voting.ts
+++ b/packages/contracts/test/plugins/governance/majority-voting/majority-voting.ts
@@ -66,7 +66,8 @@ describe('MajorityVotingMock', function () {
     const MajorityVotingBase = await ethers.getContractFactory(
       'MajorityVotingMock'
     );
-    votingBase = await MajorityVotingBase.deploy();
+
+    votingBase = await deployWithProxy(MajorityVotingBase);
     await dao.grant(
       votingBase.address,
       ownerAddress,


### PR DESCRIPTION
## Description

Best practice by OZ and auditor suggestions recommend to call  `_disableInitializers` for proxy contracts to not leave them uninitialized. 
This PR moves `_disableInitializers` inside `PluginCloneable` and `PluginUUPSUpgradeable` constructors so that people cannot accidentally forget.

After double-checking with OZ, nothing speaks against moving it into the parent constructor: https://forum.openzeppelin.com/t/putting-disableinitializers-in-a-parent-constructor/34771/3

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.