### PR TITLE
Fix the subgraph execution criteria

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UPCOMING]
 
+### Changed
+
+- Fixed the `supportThresholdReachedEarly` check in `handleVoteCast` of `TokenVoting` and `AddresslistVoting`.
+
 ## 0.9.0-alpha
+
 On 2023-02-16 16:23:28
 
 ## 0.7.1-alpha

--- a/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
+++ b/packages/subgraph/src/packages/addresslist/addresslist-voting.ts
@@ -151,8 +151,9 @@ export function handleVoteCast(event: VoteCast): void {
         let abstain = tally.abstain;
         let yes = tally.yes;
         let no = tally.no;
-        let castedVotingPower = yes.plus(no.plus(abstain));
+        let castedVotingPower = yes.plus(no).plus(abstain);
         let totalVotingPower = totalVotingPowerCall.value;
+        let noVotesWorstCase = totalVotingPower.minus(yes).minus(abstain);
 
         let supportThreshold = parameters.supportThreshold;
         let minVotingPower = parameters.minVotingPower;
@@ -165,13 +166,13 @@ export function handleVoteCast(event: VoteCast): void {
         proposalEntity.castedVotingPower = castedVotingPower;
 
         // check if the current vote results meet the conditions for the proposal to pass:
-        // - worst-case support :  N_yes / (N_total - N_abstain) > support threshold
-        // - participation      :  (N_yes + N_no + N_abstain) / N_total >= minimum participation
 
+        // `(1 - supportThreshold) * N_yes > supportThreshold *  N_no,worst-case`
         let supportThresholdReachedEarly = BASE.minus(supportThreshold)
           .times(yes)
-          .ge(totalVotingPower.minus(yes).minus(abstain));
+          .gt(supportThreshold.times(noVotesWorstCase));
 
+        // `N_yes + N_no + N_abstain >= minVotingPower = minParticipation * N_total`
         let minParticipationReached = castedVotingPower.ge(minVotingPower);
 
         // set the executable param

--- a/packages/subgraph/src/packages/token/token-voting.ts
+++ b/packages/subgraph/src/packages/token/token-voting.ts
@@ -168,8 +168,9 @@ export function handleVoteCast(event: VoteCast): void {
         let abstain = tally.abstain;
         let yes = tally.yes;
         let no = tally.no;
-        let castedVotingPower = yes.plus(no.plus(abstain));
+        let castedVotingPower = yes.plus(no).plus(abstain);
         let totalVotingPower = totalVotingPowerCall.value;
+        let noVotesWorstCase = totalVotingPower.minus(yes).minus(abstain);
 
         let supportThreshold = parameters.supportThreshold;
         let minVotingPower = parameters.minVotingPower;
@@ -182,13 +183,13 @@ export function handleVoteCast(event: VoteCast): void {
         proposalEntity.castedVotingPower = castedVotingPower;
 
         // check if the current vote results meet the conditions for the proposal to pass:
-        // - worst-case support :  N_yes / (N_total - N_abstain) > support threshold
-        // - participation      :  (N_yes + N_no + N_abstain) / N_total >= minimum participation
 
+        // `(1 - supportThreshold) * N_yes > supportThreshold *  N_no,worst-case`
         let supportThresholdReachedEarly = BASE.minus(supportThreshold)
           .times(yes)
-          .ge(totalVotingPower.minus(yes).minus(abstain));
+          .gt(supportThreshold.times(noVotesWorstCase));
 
+        // `N_yes + N_no + N_abstain >= minVotingPower = minParticipation * N_total`
         let minParticipationReached = castedVotingPower.ge(minVotingPower);
 
         // set the executable param


### PR DESCRIPTION
## Description

This PR fixes the wrong `supportThresholdReachedEarly` calculation for `TokenVoting` and `AddresslistVoting` **on the subgraph side**.

For comparision, these are the two execution criteria on the contract side that will be checked also for the `event VoteCast`:

##### `isSupportThresholdReachedEarly` (early, because the vote is still open if `event VoteCast` is emitted):
https://github.com/aragon/core/blob/3e411fcc571326c30a89f588d72c4f52236d310b/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol#L335-L337
##### `isMinParticipationReached`:
https://github.com/aragon/core/blob/3e411fcc571326c30a89f588d72c4f52236d310b/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol#L346-L348

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.